### PR TITLE
Harden configure-efa-fsx-lustre-client startup against IMDS race at boot

### DIFF
--- a/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx.sh
+++ b/1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx.sh
@@ -107,6 +107,66 @@ verify_fsx_efa_compatibility()
     return 0
 }
 
+# Gate configure-efa-fsx-lustre-client.service on IMDS readiness and retry failures
+# (the shipped unit is a oneshot with no Restart=, and network-online.target does not
+# guarantee IMDS is reachable yet)
+harden_efa_client_service_startup()
+{
+    local imds_wait_script="/usr/local/sbin/wait-for-ec2-imds"
+    local dropin_dir="/etc/systemd/system/configure-efa-fsx-lustre-client.service.d"
+
+    sudo tee "$imds_wait_script" > /dev/null <<'EOF'
+#!/usr/bin/env bash
+
+set -u
+
+readonly imds_base_url="http://169.254.169.254/latest"
+readonly deadline=$((SECONDS + 120))
+
+while ((SECONDS < deadline)); do
+    token="$(
+        curl --fail --silent --show-error \
+            --connect-timeout 2 \
+            --max-time 3 \
+            --request PUT \
+            --header "X-aws-ec2-metadata-token-ttl-seconds: 21600" \
+            "${imds_base_url}/api/token" 2>/dev/null
+    )"
+
+    if [[ -n "$token" ]] && curl --fail --silent --show-error \
+        --connect-timeout 2 \
+        --max-time 3 \
+        --header "X-aws-ec2-metadata-token: $token" \
+        "${imds_base_url}/meta-data/instance-type" >/dev/null 2>&1; then
+        exit 0
+    fi
+
+    echo "[INFO] EC2 instance metadata is not ready; retrying in 2 seconds"
+    sleep 2
+done
+
+echo "[ERROR] EC2 instance metadata did not become ready within 2 minutes" >&2
+exit 1
+EOF
+    sudo chmod 0755 "$imds_wait_script"
+
+    sudo mkdir -p "$dropin_dir"
+    sudo tee "$dropin_dir/network-readiness.conf" > /dev/null <<EOF
+[Unit]
+After=cloud-init.service
+Wants=cloud-init.service
+StartLimitIntervalSec=600
+StartLimitBurst=20
+
+[Service]
+ExecStartPre=$imds_wait_script
+Restart=on-failure
+RestartSec=10s
+EOF
+
+    sudo systemctl daemon-reload
+}
+
 # Configure EFA for Lustre if supported
 configure_efa_lustre()
 {
@@ -145,8 +205,13 @@ configure_efa_lustre()
     # Extract the zip file
     ansible localhost -m ansible.builtin.unarchive -a "src=/tmp/configure-efa-fsx-lustre-client.zip dest=/tmp remote_src=yes"
 
-    # Make script executable and run it
+    # Make script executable
     ansible localhost -b -m ansible.builtin.file -a "path=/tmp/configure-efa-fsx-lustre-client/setup.sh mode='0755'"
+
+    # Install the IMDS readiness override before setup.sh creates and starts the unit
+    harden_efa_client_service_startup
+
+    # Run the setup script
     ansible localhost -b -m ansible.builtin.command -a "/tmp/configure-efa-fsx-lustre-client/setup.sh"
 
     # Cleanup


### PR DESCRIPTION
## Purpose

`configure_efa_lustre()` in `mount_fsx.sh` (added in #849) downloads and runs the `configure-efa-fsx-lustre-client` sample from the FSx documentation, whose `setup.sh` installs a systemd service that queries EC2 instance metadata (IMDS) to configure the EFA/Lustre client.

That unit is `Type=oneshot`, ordered only on `network-online.target`, with no `Restart=` directive — and its IMDS queries have no retry. `network-online.target` means a link has an IP; it does **not** guarantee the IMDS endpoint is answering yet. On a cold boot the unit can start, miss IMDS by a few seconds, exit non-zero, and stay `failed` for the rest of the instance's life with nothing to retry it. The node then runs without the EFA LNet configuration and Lustre silently falls back to TCP — a failure mode easy to misdiagnose as a hardware/AMI problem.

## Changes

- Add `harden_efa_client_service_startup()`, invoked before `setup.sh` runs so the override is already in place when the unit is created and started:
  - installs `/usr/local/sbin/wait-for-ec2-imds`, a small readiness script that polls the IMDSv2 token endpoint plus a metadata read (short curl timeouts, 2-minute deadline);
  - installs a systemd drop-in for `configure-efa-fsx-lustre-client.service` with `ExecStartPre=` pointing at that script, `Restart=on-failure` / `RestartSec=10s`, and `StartLimitIntervalSec=600` / `StartLimitBurst=20` so retries aren't cut off by the default start-limit.
- The vendor zip itself is not modified — this only changes how the installed unit is supervised.

## Test Plan

**Environment:**
- AWS Service: SageMaker HyperPod (Slurm), FSx for Lustre created with EFA enabled
- Instance type: EFA-capable GPU instances
- Number of nodes: multi-node cluster

**Test commands:**
```bash
bash -n 1.architectures/5.sagemaker-hyperpod/LifecycleScripts/base-config/mount_fsx.sh

# on a node after boot:
systemctl cat configure-efa-fsx-lustre-client.service   # shows the drop-in
journalctl -u configure-efa-fsx-lustre-client.service   # ExecStartPre polling, retries
systemctl is-active configure-efa-fsx-lustre-client.service
```

## Test Results

- Before: on cold boots where the unit's first IMDS query raced instance-metadata availability (observed unresponsive ~3s after `network-online.target`), the service failed within seconds of boot and remained permanently `failed`; `kefalnd` never loaded, no `efa` LNet net existed, and the Lustre mount ran over TCP with no visible error.
- After: `ExecStartPre` waits for IMDS readiness before the vendor script runs; transient failures are retried per `Restart=on-failure`; the service reaches `active` and EFA transport verification (LNet send/recv counter deltas under generated I/O) passes.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`). *(N/A — no new dependencies; the vendor zip URL is the one already used by this script)*
- [ ] A README is included or updated with prerequisites, instructions, and known issues. *(N/A — focused hardening fix)*
- [ ] New test cases follow the expected directory structure. *(N/A — not a test case)*

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
