### PR TITLE
fix(hyperpod-eks-tf): prevent command injection in task_governance lo…

### DIFF
--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/task_governance/main.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/task_governance/main.tf
@@ -91,6 +91,13 @@ resource "aws_eks_addon" "task_governance" {
 
 resource "null_resource" "wait_for_kueue_webhook" {
   provisioner "local-exec" {
+    # Pass user-controllable values via the environment map instead of
+    # interpolating them into the command string. This neutralizes shell
+    # metacharacters in the variable values (command injection, CWE-78).
+    environment = {
+      AWS_REGION       = var.aws_region
+      EKS_CLUSTER_NAME = var.eks_cluster_name
+    }
     command = <<-EOT
       set -eu
       echo "Waiting for kueue-controller-manager deployment to be ready..."
@@ -99,8 +106,8 @@ resource "null_resource" "wait_for_kueue_webhook" {
       trap 'rm -f "$KUBECONFIG_FILE"' 0
 
       aws eks update-kubeconfig \
-        --region ${var.aws_region} \
-        --name ${var.eks_cluster_name} \
+        --region "$AWS_REGION" \
+        --name "$EKS_CLUSTER_NAME" \
         --kubeconfig "$KUBECONFIG_FILE"
       kubectl wait --for=condition=available deployment/kueue-controller-manager \
         -n kueue-system \

--- a/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/task_governance/variables.tf
+++ b/1.architectures/7.sagemaker-hyperpod-eks/terraform-modules/hyperpod-eks-tf/modules/task_governance/variables.tf
@@ -1,11 +1,21 @@
 variable "eks_cluster_name" {
   description = "The name of the EKS cluster"
   type        = string
+
+  validation {
+    condition     = can(regex("^[0-9A-Za-z][A-Za-z0-9_-]{0,99}$", var.eks_cluster_name))
+    error_message = "eks_cluster_name must follow EKS cluster naming rules: 1-100 characters, start with a letter or digit, and contain only letters, digits, hyphens, and underscores. This allowlist rejects shell metacharacters before any provisioner runs."
+  }
 }
 
 variable "aws_region" {
   description = "AWS Region where the HyperPod cluster and compute allocations exist"
   type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]+$", var.aws_region))
+    error_message = "aws_region must contain only lowercase letters, digits, and hyphens (e.g. us-west-2). This allowlist rejects shell metacharacters before any provisioner runs."
+  }
 }
 
 variable "hyperpod_cluster_arn" {


### PR DESCRIPTION
…cal-exec

The wait_for_kueue_webhook provisioner interpolated the user-controllable variables eks_cluster_name and aws_region directly into a local-exec command string. Terraform passes that string to /bin/sh -c, so shell metacharacters in the values (e.g. "name; touch /tmp/pwned; #") execute arbitrary commands on the host running terraform apply (OS command injection, CWE-78).

Fix, matching the pattern used in awslabs/security-hardened-amis-for-eks (v20260518):
- Add allowlist validation blocks to eks_cluster_name and aws_region so metacharacter payloads are rejected at plan time.
- Pass both values via the local-exec environment map and reference them as quoted shell variables, so their contents are never parsed as command syntax.

The compute_quota provisioners in this module already use the environment map pattern and are unaffected.

## Purpose

<!-- Link related issues using "Fixes #123" or "Relates to #123" -->

## Changes

<!-- Summarize the changes made in this PR -->

-

## Test Plan

<!-- Describe how you tested these changes -->

**Environment:**
- AWS Service:
- Instance type:
- Number of nodes:

**Test commands:**
```bash

```

## Test Results

<!-- Share relevant metrics, logs, or screenshots -->

## Directory Structure

<!-- If adding or updating a test case, ensure it follows the expected layout below. -->

```
3.test_cases/
└── <framework>/                # e.g. pytorch, megatron, jax
    └── <library>/              # e.g. picotron, FSDP, megatron-lm
        └── <model>/            # e.g. SmolLM-1.7B (may be omitted for single-model cases)
            ├── Dockerfile      # Container / environment setup
            ├── README.md       # Overview, prerequisites, usage
            ├── slurm/          # Slurm-specific launch scripts
            ├── kubernetes/     # Kubernetes manifests
            └── hyperpod-eks/   # HyperPod EKS instructions
```

- Top-level files (`Dockerfile`, `README.md`, training scripts, configs) cover general setup.
- Subdirectories (`slurm/`, `kubernetes/`, `hyperpod-eks/`) contain service-specific launch instructions.
- Not all service subdirectories are required — include only the ones relevant to your test case.

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-training/blob/main/CONTRIBUTING.md).
- [ ] I am working against the latest `main` branch.
- [ ] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [ ] The contribution is self-contained with documentation and scripts.
- [ ] External dependencies are pinned to a specific version or tag (no `latest`).
- [ ] A README is included or updated with prerequisites, instructions, and known issues.
- [ ] New test cases follow the [expected directory structure](#directory-structure).
