### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ Thanks to all the contributors for building, reviewing and testing.
 
 ## 7. Star History
 
-[![Star History Chart](https://star-history.dera.page/svg?repos=awslabs/awsome-distributed&type=Date)](https://star-history.dera.page/#awslabs/awsome-distributed&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=awslabs/awsome-distributed-ai&type=Date)](https://star-history.dera.page/#awslabs/awsome-distributed-ai&Date)

--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ Thanks to all the contributors for building, reviewing and testing.
 
 ## 7. Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=awslabs/awsome-distributed&type=Date)](https://star-history.com/#awslabs/awsome-distributed&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=awslabs/awsome-distributed&type=Date)](https://star-history.dera.page/#awslabs/awsome-distributed&Date)


### PR DESCRIPTION
The star history chart embedded in the README is broken, as it relies on a data source that is now restricted by GitHub's stargazer API limits. This change updates the chart to use a working alternative that requires no API token, so the chart renders correctly again. No other functionality is affected.