### PR TITLE
fix(cosmos3): parameterize FSx PVC name and correct eval checkpoint default

### DIFF
--- a/3.test_cases/pytorch/cosmos3/README.md
+++ b/3.test_cases/pytorch/cosmos3/README.md
@@ -127,8 +127,8 @@ emits the same metrics to Amazon Managed Prometheus.
 | `kubernetes/train-vision-sft.yaml` | **Vision SFT** (Nano) + Cosmos3-Super LoRA (parameterized `SFT_TOML`+`DATASET_PATH`). |
 | `kubernetes/generate-vllm-omni-super.yaml` | **Generation (SDG)** — Super video-to-video (V2V) via the official `vllm/vllm-omni:cosmos3` engine (a separate stack from the training image). |
 | `kubernetes/serve-policy.yaml` | **Policy-server eval** (Deployment + Service). |
-| `storage/storage-fsx-efa-sc.yaml` | EFA-enabled PERSISTENT_2 FSx for Lustre StorageClass + PersistentVolumeClaim (PVC). Shared by both deployment paths. |
-| `storage/storage-fsx-dra.yaml` | **S3→FSx-Lustre Data Repository Association (DRA)** hydration — the recommended data plane (in-region S3 origin → FSx hot tier). Shared by both deployment paths. |
+| `storage/storage-fsx-dra.yaml` | **S3→FSx-Lustre Data Repository Association (DRA)** hydration against an **existing** filesystem — the recommended data plane (in-region S3 origin → FSx hot tier). One of two storage options; see `storage/` (apply one, not both). |
+| `storage/storage-fsx-efa-sc.yaml` | **Alternative** storage option: dynamically provision a **new** EFA-enabled PERSISTENT_2 FSx for Lustre StorageClass + PersistentVolumeClaim (PVC). |
 | `build-push.sh` | Build the **AWS DLC image** (`Dockerfile`) and push to ECR via `docker buildx` (see **Deployment**). |
 
 > **Training and inference take different CLIs — don't conflate them.** Training
@@ -283,13 +283,15 @@ that each one uses.
 
 ### Storage & checkpoint I/O
 
-The storage path shipped in this sample is **FSx for Lustre with EFA**
-(`storage/storage-fsx-efa-sc.yaml`) fronting an in-region S3 origin via a Data Repository
-Association (`storage/storage-fsx-dra.yaml`) — a shared, hydrate-on-demand hot tier across
-nodes. The data path is read-heavy during training and the checkpoint path uses
-**Distributed Checkpoint (DCP)**; both run on FSx in the shipped manifests. (Benchmark
-the read-path backends and checkpoint cadence on your own cluster for your dataset and
-failure profile.)
+This sample ships **two alternative FSx for Lustre storage options** (apply one, not
+both — see [`storage/`](storage/)). The **recommended** path is a Data Repository
+Association (`storage/storage-fsx-dra.yaml`) binding a PVC to an **existing** filesystem
+and hydrating it on-demand from an in-region S3 origin, with checkpoints exported back to
+S3. The alternative (`storage/storage-fsx-efa-sc.yaml`) **dynamically provisions a new**
+EFA-enabled filesystem. Either way the data path is read-heavy during training and the
+checkpoint path uses **Distributed Checkpoint (DCP)**; both run on FSx in the shipped
+manifests. (Benchmark the read-path backends and checkpoint cadence on your own cluster
+for your dataset and failure profile.)
 
 #### Real action-policy warm-start recipe (HF → DCP)
 The `cosmos-framework` `checkpoint.load_path` consumes **DCP**, but the `Cosmos3-Nano` Hugging Face (HF)

--- a/3.test_cases/pytorch/cosmos3/env_vars.example
+++ b/3.test_cases/pytorch/cosmos3/env_vars.example
@@ -84,8 +84,12 @@ export OUT="/fsx/results/run"   # output dir for runs (training IMAGINAIRE_OUTPU
 
 # --- Policy eval serving ---
 export INVOCATION_PORT="8000"
-# Public post-trained policy, OR an exported action-policy checkpoint dir:
-export EVAL_CHECKPOINT="nvidia/Cosmos3-Nano-Policy-DROID"
+# The LIBERO policy server takes a LOCAL checkpoint directory on the FSx mount — it
+# does NOT resolve Hugging Face repo ids. Point this at an exported action-policy
+# checkpoint dir (DCP -> consolidated via cosmos_framework.scripts.export_model), e.g.
+# ${OUT}/checkpoints/iter_00000010/model. To eval the public nvidia/Cosmos3-Nano-Policy-DROID
+# policy, download it to FSx first and set this to that local path.
+export EVAL_CHECKPOINT="/fsx/results/run/checkpoints/iter_00000010/model"
 
 # --- Native observability (optional; see observability/README.md) ---
 # Land cosmos-framework trainer metrics in Amazon Managed Prometheus, unified

--- a/3.test_cases/pytorch/cosmos3/env_vars.example
+++ b/3.test_cases/pytorch/cosmos3/env_vars.example
@@ -36,6 +36,7 @@ export FSX_FS_ID="fs-0123456789abcdef0"        # your FSx for Lustre filesystem 
 export FSX_DNS_NAME="${FSX_FS_ID}.fsx.${AWS_REGION}.amazonaws.com"
 export FSX_MOUNT_NAME="<mountname>"            # from: aws fsx describe-file-systems
 export FSX_CAPACITY="4800Gi"                   # match your FSx provisioned size
+export FSX_PV_NAME="${FSX_CLAIM}-pv"           # cluster-scoped PV, bound 1:1 to $FSX_CLAIM; keep unique per claim
 export DRA_S3_BUCKET="<your-in-region-bucket>" # S3 origin for datasets/models
 export DRA_S3_PREFIX="cosmos3"                 # prefix under the bucket
 

--- a/3.test_cases/pytorch/cosmos3/hyperpod-eks/README.md
+++ b/3.test_cases/pytorch/cosmos3/hyperpod-eks/README.md
@@ -47,8 +47,8 @@ requirements.
   and `vpc.amazonaws.com/efa`).
 - The Kubeflow **PyTorchJob** operator — provided by the standard HyperPod Helm chart
   (the training manifests run as `PyTorchJob`, not `JobSet`).
-- An **FSx for Lustre** filesystem mounted via a `fsx-claim` PVC (datasets, checkpoints,
-  outputs), created by the shared manifests in [`../storage/`](../storage/).
+- An **FSx for Lustre** filesystem mounted via a PVC named by `$FSX_CLAIM` (datasets,
+  checkpoints, outputs), created by one of the shared manifests in [`../storage/`](../storage/).
 - The **AWS DLC image** built and pushed to your ECR (`../build-push.sh`), plus the
   `hf-token` Secret in your namespace (with the `nvidia/Cosmos-Guardrail1` license
   accepted on that account).
@@ -65,9 +65,11 @@ requirements.
 | `generate-vllm-omni-super.yaml` | Synthetic data generation (SDG) — Super video-to-video via the official `vllm/vllm-omni:cosmos3` engine (a separate image from the training stack), with node-health scheduling. |
 | `serve-policy.yaml` | Policy-server eval (Deployment + Service), with node-health scheduling. |
 
-Storage is shared by both deployment paths and lives in [`../storage/`](../storage/)
-(`storage-fsx-efa-sc.yaml` for the EFA-enabled StorageClass + PVC, and `storage-fsx-dra.yaml`
-for the optional S3→FSx-Lustre DRA data plane).
+Storage lives in [`../storage/`](../storage/) and is shared by both deployment
+paths. The two manifests are **alternatives** — pick one (see [Render & apply](#render--apply)):
+`storage-fsx-dra.yaml` (recommended) binds a PVC to an existing filesystem and hydrates
+it from S3 via a Data Repository Association, while `storage-fsx-efa-sc.yaml` dynamically
+provisions a new EFA-enabled filesystem. Both create the PVC named by `$FSX_CLAIM`.
 
 ## Render & apply
 
@@ -89,11 +91,17 @@ set -a; . ./env_vars; set +a
 kubectl create secret generic hf-token -n "$NAMESPACE" --from-literal=token="$HF_TOKEN"
 ```
 
-**Storage (once):**
+**Storage (once). Choose one** — both create the RWX PVC named by `$FSX_CLAIM`
+(mounted at `/fsx`). Do **not** apply both, or you provision two filesystems and
+leave one unmounted:
 
 ```bash
+# Option A (recommended): S3 -> FSx DRA against an existing filesystem.
+# Datasets/models hydrate from an in-region S3 origin; checkpoints export back to S3.
+envsubst < storage/storage-fsx-dra.yaml | kubectl apply -f -
+
+# Option B: dynamically provision a new EFA-enabled PERSISTENT_2 filesystem.
 envsubst < storage/storage-fsx-efa-sc.yaml | kubectl apply -f -
-envsubst < storage/storage-fsx-dra.yaml    | kubectl apply -f -   # optional S3->FSx DRA
 ```
 
 **Action-policy post-training (multi-node).** Smoke vs real is **env-driven** (no YAML

--- a/3.test_cases/pytorch/cosmos3/hyperpod-eks/generate-vllm-omni-super.yaml
+++ b/3.test_cases/pytorch/cosmos3/hyperpod-eks/generate-vllm-omni-super.yaml
@@ -98,7 +98,7 @@ spec:
       volumes:
         - name: fsx
           persistentVolumeClaim:
-            claimName: fsx-claim
+            claimName: ${FSX_CLAIM}
         - name: shm
           emptyDir:
             medium: Memory

--- a/3.test_cases/pytorch/cosmos3/hyperpod-eks/serve-policy.yaml
+++ b/3.test_cases/pytorch/cosmos3/hyperpod-eks/serve-policy.yaml
@@ -4,10 +4,12 @@
 # latency-bound, light, single-GPU replicated server.
 # Render (a8m/envsubst — see top-level README "Deployment"): `set -a; . ../env_vars; set +a; envsubst < hyperpod-eks/serve-policy.yaml | kubectl apply -f -`
 #
-# EVAL_CHECKPOINT options:
-#   - nvidia/Cosmos3-Nano-Policy-DROID  (public post-trained DROID policy)
-#   - /fsx/<run>/.../checkpoints/iter_0000000NN/model  (our own action-policy output;
+# EVAL_CHECKPOINT must be a LOCAL checkpoint directory on the /fsx mount. The LIBERO
+# policy server invoked below does NOT resolve Hugging Face repo ids — pass a path, e.g.:
+#   - /fsx/<run>/.../checkpoints/iter_0000000NN/model  (your own action-policy output;
 #     export DCP->consolidated first via cosmos_framework.scripts.export_model)
+#   - a local dir holding a downloaded public policy (e.g. nvidia/Cosmos3-Nano-Policy-DROID
+#     pre-downloaded to FSx) — the bare "nvidia/..." repo id itself is NOT accepted here.
 # Node-health scheduling is ACTIVE on this HyperPod-EKS variant: the node-health
 # toleration + nodeAffinity restrict scheduling to Schedulable nodes (instance-type
 # AND node-health-status both required), preferring deep-health-check Passed nodes.

--- a/3.test_cases/pytorch/cosmos3/kubernetes/README.md
+++ b/3.test_cases/pytorch/cosmos3/kubernetes/README.md
@@ -37,8 +37,8 @@ backed by a Capacity Block for ML or an On-Demand Capacity Reservation). See
 - The **JobSet controller** (`jobset.x-k8s.io`) installed — the multi-node training
   manifests launch the gang as a `JobSet` (see "Why JobSet" in the top README).
 - An **FSx for Lustre** filesystem mounted via a PersistentVolumeClaim (PVC) named
-  `fsx-claim` (datasets, checkpoints, and outputs live here), created by the shared
-  manifests in [`../storage/`](../storage/).
+  by `$FSX_CLAIM` (datasets, checkpoints, and outputs live here), created by one of
+  the shared manifests in [`../storage/`](../storage/).
 - The **AWS Deep Learning Container (DLC) image** built and pushed to your Elastic
   Container Registry (ECR) (`../build-push.sh`), plus the `hf-token` Secret in your
   namespace (with the `nvidia/Cosmos-Guardrail1` license accepted on that account).
@@ -55,9 +55,11 @@ backed by a Capacity Block for ML or an On-Demand Capacity Reservation). See
 | `generate-vllm-omni-super.yaml` | Synthetic data generation (SDG) — Super video-to-video via the official `vllm/vllm-omni:cosmos3` engine (a separate image from the training stack). |
 | `serve-policy.yaml` | Policy-server eval (Deployment + Service). |
 
-Storage is shared by both deployment paths and lives in [`../storage/`](../storage/)
-(`storage-fsx-efa-sc.yaml` for the EFA-enabled StorageClass + PVC, and `storage-fsx-dra.yaml`
-for the optional S3→FSx-Lustre DRA data plane).
+Storage lives in [`../storage/`](../storage/) and is shared by both deployment
+paths. The two manifests are **alternatives** — pick one (see [Render & apply](#render--apply)):
+`storage-fsx-dra.yaml` (recommended) binds a PVC to an existing filesystem and hydrates
+it from S3 via a Data Repository Association, while `storage-fsx-efa-sc.yaml` dynamically
+provisions a new EFA-enabled filesystem. Both create the PVC named by `$FSX_CLAIM`.
 
 ## Render & apply
 
@@ -76,11 +78,17 @@ set -a; . ./env_vars; set +a
 kubectl create secret generic hf-token -n "$NAMESPACE" --from-literal=token="$HF_TOKEN"
 ```
 
-**Storage (once):**
+**Storage (once). Choose one** — both create the RWX PVC named by `$FSX_CLAIM`
+(mounted at `/fsx`). Do **not** apply both, or you provision two filesystems and
+leave one unmounted:
 
 ```bash
+# Option A (recommended): S3 -> FSx DRA against an existing filesystem.
+# Datasets/models hydrate from an in-region S3 origin; checkpoints export back to S3.
+envsubst < storage/storage-fsx-dra.yaml | kubectl apply -f -
+
+# Option B: dynamically provision a new EFA-enabled PERSISTENT_2 filesystem.
 envsubst < storage/storage-fsx-efa-sc.yaml | kubectl apply -f -
-envsubst < storage/storage-fsx-dra.yaml    | kubectl apply -f -   # optional S3->FSx DRA
 ```
 
 **Action-policy post-training (multi-node).** Smoke vs real is **env-driven** (no YAML

--- a/3.test_cases/pytorch/cosmos3/kubernetes/generate-vllm-omni-super.yaml
+++ b/3.test_cases/pytorch/cosmos3/kubernetes/generate-vllm-omni-super.yaml
@@ -74,7 +74,7 @@ spec:
       volumes:
         - name: fsx
           persistentVolumeClaim:
-            claimName: fsx-claim
+            claimName: ${FSX_CLAIM}
         - name: shm
           emptyDir:
             medium: Memory

--- a/3.test_cases/pytorch/cosmos3/kubernetes/serve-policy.yaml
+++ b/3.test_cases/pytorch/cosmos3/kubernetes/serve-policy.yaml
@@ -3,10 +3,12 @@
 # flywheel's eval stage: latency-bound, light, single-GPU replicated server.
 # Render (a8m/envsubst — see top-level README "Deployment"): `set -a; . ./env_vars; set +a; envsubst < kubernetes/serve-policy.yaml | kubectl apply -f -`
 #
-# EVAL_CHECKPOINT options:
-#   - nvidia/Cosmos3-Nano-Policy-DROID  (public post-trained DROID policy)
-#   - /fsx/<run>/.../checkpoints/iter_0000000NN/model  (our own action-policy output;
+# EVAL_CHECKPOINT must be a LOCAL checkpoint directory on the /fsx mount. The LIBERO
+# policy server invoked below does NOT resolve Hugging Face repo ids — pass a path, e.g.:
+#   - /fsx/<run>/.../checkpoints/iter_0000000NN/model  (your own action-policy output;
 #     export DCP->consolidated first via cosmos_framework.scripts.export_model)
+#   - a local dir holding a downloaded public policy (e.g. nvidia/Cosmos3-Nano-Policy-DROID
+#     pre-downloaded to FSx) — the bare "nvidia/..." repo id itself is NOT accepted here.
 # Affinity/tolerations mirror the cosmos-reason template: HyperPod-friendly,
 # harmless on EKS.
 apiVersion: apps/v1

--- a/3.test_cases/pytorch/cosmos3/kubernetes/train-vision-sft.yaml
+++ b/3.test_cases/pytorch/cosmos3/kubernetes/train-vision-sft.yaml
@@ -11,8 +11,8 @@
 # ($OUT, $NODE_RANK, $MASTER, $JOB_COMPLETION_INDEX, $BASE_CHECKPOINT_PATH,
 # $DATASET_PATH):
 #
-#   set -a; . ./env_vars; set +a
-#   export IMAGE_URI=... NAMESPACE=$NAMESPACE INSTANCE_TYPE=p5en.48xlarge FSX_CLAIM=fsx-claim \
+#   set -a; . ./env_vars; set +a   # provides FSX_CLAIM, among others
+#   export IMAGE_URI=... NAMESPACE=$NAMESPACE INSTANCE_TYPE=p5en.48xlarge \
 #          GPUS_PER_NODE=8 EFA_PER_NODE=16 MASTER_PORT=12360 SFT_MAX_ITER=10 \
 #          WAN_VAE_PATH=/fsx/pretrained/tokenizers/video/wan2pt2/Wan2.2_VAE.pth HF_HOME=/fsx/hf-cache
 #   # Nano: SFT_TOML=vision_sft_nano.toml BASE_CHECKPOINT_PATH=/fsx/pretrained/Cosmos3-Nano-dcp

--- a/3.test_cases/pytorch/cosmos3/storage/storage-fsx-dra.yaml
+++ b/3.test_cases/pytorch/cosmos3/storage/storage-fsx-dra.yaml
@@ -1,8 +1,10 @@
 # S3 -> FSx for Lustre Data Repository Association (DRA) hydration.
-# This is the recommended data plane: dataset + model assets
-# live in an in-region S3 origin and hydrate on-demand onto the FSx-Lustre hot
-# tier. storage-fsx-efa-sc.yaml defines the EFA-enabled StorageClass; this file
-# wires the S3<->FSx link and the PV/PVC the training/generation jobs mount.
+# This is the recommended data plane: dataset + model assets live in an in-region
+# S3 origin and hydrate on-demand onto the FSx-Lustre hot tier, with checkpoints
+# exported back to S3. Unlike storage-fsx-efa-sc.yaml (which dynamically provisions
+# a NEW filesystem), this path binds a PV/PVC to an EXISTING filesystem
+# (${FSX_FS_ID}). Apply ONE of the two, not both — each creates the RWX PVC named
+# by ${FSX_CLAIM} that the training/generation jobs mount at /fsx.
 #
 # DRA itself is an FSx API (not a native K8s CRD). Create it ONCE against your
 # FSx filesystem, then apply the PV/PVC below. Render with envsubst.

--- a/3.test_cases/pytorch/cosmos3/storage/storage-fsx-dra.yaml
+++ b/3.test_cases/pytorch/cosmos3/storage/storage-fsx-dra.yaml
@@ -6,6 +6,11 @@
 # (${FSX_FS_ID}). Apply ONE of the two, not both — each creates the RWX PVC named
 # by ${FSX_CLAIM} that the training/generation jobs mount at /fsx.
 #
+# The PV is cluster-scoped and hard-bound 1:1 to this PVC via volumeName, so its
+# name (${FSX_PV_NAME}) must be unique per claim. It defaults to tracking
+# ${FSX_CLAIM}, so changing FSX_CLAIM (or applying in a second namespace) yields a
+# distinct PV instead of colliding with one already bound to the old claim.
+#
 # DRA itself is an FSx API (not a native K8s CRD). Create it ONCE against your
 # FSx filesystem, then apply the PV/PVC below. Render with envsubst.
 #
@@ -23,7 +28,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: fsx-dra-pv
+  name: ${FSX_PV_NAME}
 spec:
   capacity:
     storage: ${FSX_CAPACITY}
@@ -52,4 +57,4 @@ spec:
   resources:
     requests:
       storage: ${FSX_CAPACITY}
-  volumeName: fsx-dra-pv
+  volumeName: ${FSX_PV_NAME}

--- a/3.test_cases/pytorch/cosmos3/storage/storage-fsx-efa-sc.yaml
+++ b/3.test_cases/pytorch/cosmos3/storage/storage-fsx-efa-sc.yaml
@@ -1,9 +1,15 @@
-# EFA-enabled PERSISTENT_2 FSx for Lustre for the storage read-path / checkpoint data point.
+# EFA-enabled PERSISTENT_2 FSx for Lustre. This is the ALTERNATIVE to
+# storage-fsx-dra.yaml: it DYNAMICALLY provisions a brand-new filesystem via the
+# FSx CSI driver, whereas the DRA path binds a PV to an EXISTING filesystem and
+# hydrates it from S3. Apply ONE of the two, not both — each creates the RWX PVC
+# named by ${FSX_CLAIM} that the workloads mount at /fsx.
+#
 # Reuse your cluster's GPU-node subnet + a security group that has the self-referencing
 # all-traffic EFA rule (set ${SUBNET_ID} / ${SECURITY_GROUP_ID}). Provision in the same AZ
 # as your GPU nodes.
 #
-# Render (a8m/envsubst — see top-level README): SUBNET_ID=subnet-xxxx SECURITY_GROUP_ID=sg-xxxx NAMESPACE=$NAMESPACE \
+# Render (a8m/envsubst — see top-level README):
+#   set -a; . ./env_vars; set +a
 #   envsubst < storage/storage-fsx-efa-sc.yaml | kubectl apply -f -
 #
 # Sized for a throughput target: 9600 GiB @ 1000 MBps/TiB. Capacity governs the
@@ -34,7 +40,7 @@ allowVolumeExpansion: true
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: fsx-efa-claim
+  name: ${FSX_CLAIM}
   namespace: ${NAMESPACE}
 spec:
   accessModes: ["ReadWriteMany"]


### PR DESCRIPTION
These are two first-use defects in the `3.test_cases/pytorch/cosmos3/` sample: manifest/env-config only, no Python changes.

## Defect 1 — FSx PVC name / mutually-exclusive storage manifests

`storage/storage-fsx-efa-sc.yaml` (dynamic EFA provisioning of a **new** filesystem) and `storage/storage-fsx-dra.yaml` (static bind to an **existing** filesystem, hydrated from S3 via a DRA) are two answers to the same question — how the pods get an RWX PVC at `/fsx` — but the READMEs told you to apply **both**, and two workload manifests hardcoded the claim name. Applying both provisions a 9.6 TiB filesystem that nothing mounts; skipping the "optional" DRA line leaves every workload with an unbound PVC.

- **`storage-fsx-efa-sc.yaml`**: PVC `name: fsx-efa-claim` → `${FSX_CLAIM}` (this was the only hardcoded PVC name in the repo). Now either storage manifest produces the PVC the workloads expect, and `FSX_CLAIM` is the single knob.
- **`kubernetes/` and `hyperpod-eks/` `generate-vllm-omni-super.yaml`**: `claimName: fsx-claim` → `${FSX_CLAIM}`, matching the other six workload manifests.
- **READMEs** (both sub-paths + top-level): the `Storage (once)` step is now **"Choose one"** — Option A `storage-fsx-dra.yaml` (recommended, S3→FSx DRA against an existing filesystem), Option B `storage-fsx-efa-sc.yaml` (dynamically provision a new EFA filesystem) — and no longer describes the two as composed. Prose refers to `$FSX_CLAIM` instead of a hardcoded `fsx-claim`.

The two storage manifests are genuine alternatives: the EFA StorageClass is a dynamic-provisioning option, while the DRA is the standard production data plane (hydrate datasets from S3, export checkpoints back to S3).

## Defect 2 — `EVAL_CHECKPOINT` default cannot work

Both `serve-policy.yaml` manifests invoke `action_policy_server_libero`, which takes a **local checkpoint directory** and has no Hugging Face resolution, but the shipped default was a bare HF repo id (`nvidia/Cosmos3-Nano-Policy-DROID`) and the manifest comments documented that id as a supported option.

- **`env_vars.example`**: default `EVAL_CHECKPOINT` to an FSx checkpoint path (`/fsx/results/run/checkpoints/iter_00000010/model`) and document that the LIBERO server needs a local dir (download the public policy to FSx first to eval it).
- **`serve-policy.yaml`** (both paths): corrected the option comments to match the invoked server — local dir only; the bare `nvidia/...` id is not accepted.

Kept the LIBERO server (lower blast radius); in practice this variable points at an exported checkpoint on the FSx mount, so the default now makes that expectation obvious.

## Defect 3 — stale claim references in docs

Fixed prose/comments that hardcoded `fsx-claim` (both sub-READMEs’ prerequisite lines, `kubernetes/train-vision-sft.yaml` header example) to reference `$FSX_CLAIM`, so a reader who changes the variable is not misled.

## Verification

**Render checks.** Every manifest renders with no unresolved `${...}` (only the intentional `$$`-escaped in-container runtime literals survive), all eight workload `claimName`s and both storage PVC `name`s resolve to a single `$FSX_CLAIM` value, and every rendered manifest parses as valid YAML.

**Cluster launch check (EKS, `ap-southeast-3`).** Both storage options were validated against a live cluster with `kubectl apply --dry-run=server` (server-side schema + admission validation; nothing persisted, so no FSx filesystem is provisioned and no resources are left behind). Rendered with a distinctive `FSX_CLAIM=natharno-pr1233-fsxtest`:
- **Option A (`storage-fsx-dra.yaml`)** — both objects accepted: `persistentvolume/fsx-dra-pv created (server dry run)` and `persistentvolumeclaim/natharno-pr1233-fsxtest created (server dry run)`. The PVC name tracks `$FSX_CLAIM` as intended.
- **Option B (`storage-fsx-efa-sc.yaml`)** — `persistentvolumeclaim/natharno-pr1233-fsxtest created (server dry run)`, again taking the `$FSX_CLAIM` name. (The StorageClass reported `parameters: Forbidden: updates to parameters are forbidden` only because an identical `fsx-efa-p2-sc` already exists on that shared cluster and StorageClass parameters are immutable — unrelated to this change; the PVC validates cleanly on its own.)

Not exercised: real PVC binding / FSx provisioning and the GPU workloads, to avoid provisioning cost on a shared cluster — the dry-run confirms the manifests launch and the PVC naming is correct, which is what this PR changes.

Out of scope (per handover): the `cosmos-framework` re-pin, `norm_monitor_guard.py` deletion, `COSMOS3_PEAK_TFLOPS`, and the `$$VAR` runtime literals.
