### PR TITLE
chore(nccl-tests): update NCCL and EFA stack

### DIFF
--- a/.github/image-manifest.yaml
+++ b/.github/image-manifest.yaml
@@ -33,9 +33,9 @@ images:
       - amd64
       - arm64
     build_args:
-      CUDA_VERSION: "13.0.2"
-      GDRCOPY_VERSION: "v2.5.2"
-      EFA_INSTALLER_VERSION: "1.48.0"
-      AWS_OFI_NCCL_VERSION: "v1.19.0"
-      NCCL_VERSION: "v2.30.4-1"
-      NCCL_TESTS_VERSION: "v2.18.3"
+      CUDA_VERSION: "13.1.2"
+      GDRCOPY_VERSION: "v2.6"
+      EFA_INSTALLER_VERSION: "1.50.0"
+      AWS_OFI_NCCL_VERSION: "v1.21.1"
+      NCCL_VERSION: "v2.31.2-1"
+      NCCL_TESTS_VERSION: "v2.20.0"

--- a/micro-benchmarks/nccl-tests/README.md
+++ b/micro-benchmarks/nccl-tests/README.md
@@ -22,11 +22,11 @@ If you are using EKS, this guide assumes that you have the following:
 - A functional EKS cluster on AWS. <br/>
 To create one, use an EKS provisioning method supported by your organization.
 - NVIDIA device plugin deployed to your cluster. <br/>
-For deployment options, see the [NVIDIA Kubernetes device plugin v0.20.0](https://github.com/NVIDIA/k8s-device-plugin/releases/tag/v0.20.0).
+For deployment options, see the [NVIDIA Kubernetes device plugin](https://github.com/NVIDIA/k8s-device-plugin).
 - EFA device plugin deployed to your cluster. <br/>
-For deployment options, see [aws-efa-eks at commit d801012](https://github.com/aws-samples/aws-efa-eks/tree/d801012b690f0cd17b8e7d5c4231a909faea7c81).
+For deployment instructions, see [Install the EFA device plugin](https://docs.aws.amazon.com/eks/latest/userguide/node-efa.html).
 - Kubeflow MPI operator deployed to your cluster. <br/>
-For deployment options, see [Kubeflow MPI Operator at commit 1e20021](https://github.com/kubeflow/mpi-operator/tree/1e200217cf1ffcdb1ea45d055f913767dff82ed9).
+For deployment options, see [Kubeflow MPI Operator](https://github.com/kubeflow/mpi-operator).
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#cliv2-linux-install)
 
 ## 1. Prepare the container image and other artifacts

--- a/micro-benchmarks/nccl-tests/README.md
+++ b/micro-benchmarks/nccl-tests/README.md
@@ -20,51 +20,54 @@ It is recommended that you use the templates in the architectures [directory](..
 If you are using EKS, this guide assumes that you have the following:
 
 - A functional EKS cluster on AWS. <br/>
-To set up one, please refer to [aws-do-eks](https://bit.ly/do-eks), [Amazon EKS Blueprints for Terraform](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main), [Amazon EKS Blueprints for CDK](https://aws-quickstart.github.io/cdk-eks-blueprints/), or others.
+To create one, use an EKS provisioning method supported by your organization.
 - NVIDIA device plugin deployed to your cluster. <br/>
-If you need to deploy it, please refer to [deployment/nvidia-device-plugin](https://github.com/aws-samples/aws-do-eks/blob/main/Container-Root/eks/deployment/nvidia-device-plugin) or [k8s-device-plugin/deployments](https://github.com/NVIDIA/k8s-device-plugin/tree/main/deployments).
+For deployment options, see the [NVIDIA Kubernetes device plugin v0.20.0](https://github.com/NVIDIA/k8s-device-plugin/releases/tag/v0.20.0).
 - EFA device plugin deployed to your cluster. <br/>
-If you need to deploy it, please refer to [deployment/efa-device-plugin](https://github.com/aws-samples/aws-do-eks/tree/main/Container-Root/eks/deployment/efa-device-plugin) or [aws-efa-eks](https://github.com/aws-samples/aws-efa-eks).
+For deployment options, see [aws-efa-eks at commit d801012](https://github.com/aws-samples/aws-efa-eks/tree/d801012b690f0cd17b8e7d5c4231a909faea7c81).
 - Kubeflow MPI operator deployed to your cluster. <br/>
-If you need to deploy it, please refer to [deployment/kubeflow/mpi-operator](https://github.com/aws-samples/aws-do-eks/tree/main/Container-Root/eks/deployment/kubeflow/mpi-operator) or [kubeflow/mpi-operator](https://github.com/kubeflow/mpi-operator).
+For deployment options, see [Kubeflow MPI Operator at commit 1e20021](https://github.com/kubeflow/mpi-operator/tree/1e200217cf1ffcdb1ea45d055f913767dff82ed9).
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#cliv2-linux-install)
 
 ## 1. Prepare the container image and other artifacts
 
 The NCCL tests are packaged in a container.
 
-> You can set versions and the branch for NCCL and EFA by editing the variables below in the Dockerfile.
+The container pins the following mutually compatible release set. EFA installer 1.50.0 bundles aws-ofi-nccl 1.21.1 and libfabric 2.6.0amzn1.0; the [aws-ofi-nccl 1.21.1 release notes](https://github.com/aws/aws-ofi-nccl/releases/tag/v1.21.1) identify NCCL 2.31.2-1 as its tested NCCL release, and the [EFA installer 1.50.0 release notes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-changelog.html) identify the bundled plugin version.
 
 > | Variable              | Default     | Repository                                                                                  |
 > |-----------------------|-------------|---------------------------------------------------------------------------------------------|
-> |`CUDA_VERSION`         | `13.0.2`    |                                                                                             |
-> |`GDRCOPY_VERSION`      | `v2.5.2`    | [link](https://github.com/NVIDIA/gdrcopy)                                                   |
-> |`EFA_INSTALLER_VERSION`| `1.48.0`    | [link](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-enable) |
-> |`AWS_OFI_NCCL_VERSION` | *(deprecated)* | AWS OFI NCCL plugin is now bundled with EFA installer                                    |
-> |`NCCL_VERSION`         | `v2.30.4-1` | [link](https://github.com/NVIDIA/nccl)                                                      |
-> |`NCCL_TESTS_VERSION`   | `v2.18.3`   | [link](https://github.com/NVIDIA/nccl-tests)                                                |
+> |`CUDA_VERSION`         | `13.1.2`    | [CUDA container tag](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags)       |
+> |`GDRCOPY_VERSION`      | `v2.6`      | [GDRCopy v2.6](https://github.com/NVIDIA/gdrcopy/releases/tag/v2.6)                         |
+> |`EFA_INSTALLER_VERSION`| `1.50.0`    | [EFA release notes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-changelog.html) |
+> |aws-ofi-nccl           | `v1.21.1`   | [aws-ofi-nccl v1.21.1](https://github.com/aws/aws-ofi-nccl/releases/tag/v1.21.1), bundled by EFA installer 1.50.0 |
+> |`NCCL_VERSION`         | `v2.31.2-1` | [NCCL v2.31.2-1](https://github.com/NVIDIA/nccl/releases/tag/v2.31.2-1)                     |
+> |`NCCL_TESTS_VERSION`   | `v2.20.0`   | [nccl-tests v2.20.0](https://github.com/NVIDIA/nccl-tests/releases/tag/v2.20.0)             |
 
-The image is built with `NVCC_GENCODE` covering `sm_80`, `sm_86`, `sm_89`, `sm_90`, `sm_100`, and `sm_103` — i.e. native binaries for A100, RTX 30/Ada/Lovelace, H100/H200, B200/GB200, and B300/GB300. PTX is not embedded; if you target a newer architecture, add it to the `NVCC_GENCODE` lines in `nccl-tests.Dockerfile`.
+The image is built with `NVCC_GENCODE` covering `sm_80`, `sm_86`, `sm_89`, `sm_90`, `sm_100`, and `sm_103`, which provides native binaries for A100, RTX 30/Ada/Lovelace, H100/H200, B200/GB200, and B300/GB300. PTX is not embedded; add a new architecture to both `NVCC_GENCODE` lines in `nccl-tests.Dockerfile` before targeting it.
 
-You must pick each version of the library and set them as variables before proceed:
+Set the pinned versions and image tag from the `micro-benchmarks/nccl-tests` directory:
 
 ```bash
-GDRCOPY_VERSION=v2.5.2
-EFA_INSTALLER_VERSION=1.48.0
-NCCL_VERSION=v2.30.4-1
-NCCL_TESTS_VERSION=v2.18.3
-TAG="efa${EFA_INSTALLER_VERSION}-nccl${NCCL_VERSION}-tests${NCCL_TESTS_VERSION}"
+CUDA_VERSION=13.1.2
+GDRCOPY_VERSION=v2.6
+EFA_INSTALLER_VERSION=1.50.0
+AWS_OFI_NCCL_VERSION=v1.21.1
+NCCL_VERSION=v2.31.2-1
+NCCL_TESTS_VERSION=v2.20.0
+TAG="cuda${CUDA_VERSION}-efa${EFA_INSTALLER_VERSION}-ofi${AWS_OFI_NCCL_VERSION}-nccl${NCCL_VERSION}-tests${NCCL_TESTS_VERSION}"
 CONTAINER_IMAGE_NAME_TAG="nccl-tests:${TAG}"
 ```
 
 ### Build the container
 
-If you wish to build the containar image by yourself, follow this section. Alternatively, you can use a prebuild image on a public ECR repository `public.ecr.aws/hpc-cloud/nccl-tests`. If you wish to do so, skip this section.
+Build the container locally with the commands below, or use the matching pinned tag from `public.ecr.aws/hpc-cloud/nccl-tests` after that tag has been published.
 
 1. Build the container image with the command below:
 
    ```bash
    docker build -f nccl-tests.Dockerfile \
+          --build-arg="CUDA_VERSION=${CUDA_VERSION}" \
           --build-arg="GDRCOPY_VERSION=${GDRCOPY_VERSION}" \
           --build-arg="EFA_INSTALLER_VERSION=${EFA_INSTALLER_VERSION}" \
           --build-arg="NCCL_VERSION=${NCCL_VERSION}" \
@@ -79,9 +82,9 @@ If you wish to build the containar image by yourself, follow this section. Alter
 
    ```
    REPOSITORY               TAG                        IMAGE ID       CREATED         SIZE
-   nccl                     latest                     6e981e5cf6a5   5 hours ago     8.61GB
+   nccl-tests               cuda13.1.2-efa1.50.0-ofiv1.21.1-ncclv2.31.2-1-testsv2.20.0   <image-id>   <created>   <size>
    ...
-   nvidia/cuda              13.0.2-devel-ubuntu22.04   a86c511c87e1   2 weeks ago     6.56GB
+   nvcr.io/nvidia/cuda      13.1.2-devel-ubuntu22.04   <image-id>   <created>   <size>
    ```
 
 ### Slurm
@@ -248,7 +251,7 @@ To change the type of collective to test, modify the line with `srun` in the fil
 
    - `slotsPerWorker: 8`: set to the number of GPUs per node in your cluster
    - `<account>.dkr.ecr.<region>.amazonaws.com/<image>:<tag>`: set to your container image URI. You may specify the public ECR image instead as `image: public.ecr.aws/hpc-cloud/nccl-tests:<tag>`. Note: change both locations in the file. You may use `echo ${CONTAINER_IMAGE_NAME_TAG}` to print the image URI.
-   - `-np 16`: set -np option in mpirun to (*`number_of_worker_nodes`* * *`number_of_gpus_per_node`*), other mpirun parameters if needed for your instance type, please refer to [aws-ofi-nccl](https://github.com/aws/aws-ofi-nccl/blob/master/doc/efa-env-var.md)
+   - `-np 16`: set `-np` to `number_of_worker_nodes * number_of_gpus_per_node`. For other `mpirun` parameters, see the [aws-ofi-nccl v1.21.1 EFA environment variables](https://github.com/aws/aws-ofi-nccl/blob/v1.21.1/doc/efa-env-var.md).
    - `replicas: 2`: set to number of worker pods you would like the test to run on. This must be less than or eaqual to the number of nodes in your cluster.
    - `node.kubernetes.io/instance-type: "p5.48xlarge"`: set to the instance type of the nodes in your cluster against which you would like the nccl test to be run
    - `nvidia.com/gpu: 8`: set to the number of GPUs per node in your cluster, adjust in both the limits and requests section
@@ -279,7 +282,7 @@ To change the type of collective to test, modify the line with `srun` in the fil
    kubectl logs -f $(kubectl get pods | grep launcher | cut -d ' ' -f 1)
    ```
 
-   The following is an example exerpt from the logs of a NCCL all_reduce_perf test, executed on a cluster with two p5.48xlarge instances (using EFA_INSTALLER_VERSION=1.28.0, NCCL_TESTS_VERSION=master, NCCL_VERSION=2.18.5):
+   The following historical output is from `all_reduce_perf` on two `p5.48xlarge` instances with EFA installer 1.28.0, nccl-tests v2.13.9, and NCCL 2.18.5. It is an output-format example, not validation of the current release set.
 
    ```log
    [1,0]<stdout>:#                                                              out-of-place                       in-place          

--- a/micro-benchmarks/nccl-tests/buildspec.yaml
+++ b/micro-benchmarks/nccl-tests/buildspec.yaml
@@ -2,12 +2,12 @@ version: 0.2
 
 env:
   variables:
-    CUDA_VERSION: "13.0.2"
-    GDRCOPY_VERSION: "v2.5.2"
-    EFA_INSTALLER_VERSION: "1.48.0"
-    AWS_OFI_NCCL_VERSION: "v1.19.0"
-    NCCL_VERSION: "v2.30.4-1"
-    NCCL_TESTS_VERSION: "v2.18.3"
+    CUDA_VERSION: "13.1.2"
+    GDRCOPY_VERSION: "v2.6"
+    EFA_INSTALLER_VERSION: "1.50.0"
+    AWS_OFI_NCCL_VERSION: "v1.21.1"
+    NCCL_VERSION: "v2.31.2-1"
+    NCCL_TESTS_VERSION: "v2.20.0"
   exported-variables:
     - CUDA_VERSION
     - GDRCOPY_VERSION
@@ -29,4 +29,4 @@ phases:
       - echo "REPO_URI=$REPO_URI"
       - echo "Building ${REPO_URI}:${TAG} ..."
       - docker buildx create --use --name multiarch
-      - cd micro-benchmarks/nccl-tests && docker buildx build --push --platform=linux/amd64,linux/arm64 --build-arg CUDA_VERSION=${CUDA_VERSION} --build-arg GDRCOPY_VERSION=$GDRCOPY_VERSION --build-arg EFA_INSTALLER_VERSION=$EFA_INSTALLER_VERSION --build-arg AWS_OFI_NCCL_VERSION=$AWS_OFI_NCCL_VERSION --build-arg NCCL_VERSION=$NCCL_VERSION --build-arg NCCL_TESTS_VERSION=$NCCL_TESTS_VERSION -t public.ecr.aws/hpc-cloud/${ECR_REPOSITORY_NAME}:${TAG} -t public.ecr.aws/hpc-cloud/${ECR_REPOSITORY_NAME}:latest -f ./nccl-tests.Dockerfile .
+      - cd micro-benchmarks/nccl-tests && docker buildx build --push --platform=linux/amd64,linux/arm64 --build-arg CUDA_VERSION=${CUDA_VERSION} --build-arg GDRCOPY_VERSION=$GDRCOPY_VERSION --build-arg EFA_INSTALLER_VERSION=$EFA_INSTALLER_VERSION --build-arg NCCL_VERSION=$NCCL_VERSION --build-arg NCCL_TESTS_VERSION=$NCCL_TESTS_VERSION -t public.ecr.aws/hpc-cloud/${ECR_REPOSITORY_NAME}:${TAG} -f ./nccl-tests.Dockerfile .

--- a/micro-benchmarks/nccl-tests/kubernetes/nccl-tests-gb200.yaml
+++ b/micro-benchmarks/nccl-tests/kubernetes/nccl-tests-gb200.yaml
@@ -26,7 +26,7 @@ spec:
          spec:
           restartPolicy: OnFailure
           containers:
-          - image: public.ecr.aws/u1m6g1t5/nccl-tests-arm64:latest
+          - image: public.ecr.aws/hpc-cloud/nccl-tests:cuda13.1.2-efa1.50.0-ofiv1.21.1-ncclv2.31.2-1-testsv2.20.0
             imagePullPolicy: IfNotPresent
             name: test-nccl-launcher
             env:
@@ -91,7 +91,7 @@ spec:
                     - mpi-worker
                 topologyKey: nvidia.com/gpu.clique
           containers:
-          - image: public.ecr.aws/u1m6g1t5/nccl-tests-arm64:latest
+          - image: public.ecr.aws/hpc-cloud/nccl-tests:cuda13.1.2-efa1.50.0-ofiv1.21.1-ncclv2.31.2-1-testsv2.20.0
             imagePullPolicy: IfNotPresent
             name: nccl-tests-worker
             volumeMounts:

--- a/micro-benchmarks/nccl-tests/kubernetes/nccl-tests-gb200.yaml
+++ b/micro-benchmarks/nccl-tests/kubernetes/nccl-tests-gb200.yaml
@@ -26,7 +26,7 @@ spec:
          spec:
           restartPolicy: OnFailure
           containers:
-          - image: public.ecr.aws/hpc-cloud/nccl-tests:cuda13.1.2-efa1.50.0-ofiv1.21.1-ncclv2.31.2-1-testsv2.20.0
+          - image: public.ecr.aws/u1m6g1t5/nccl-tests-arm64:latest
             imagePullPolicy: IfNotPresent
             name: test-nccl-launcher
             env:
@@ -91,7 +91,7 @@ spec:
                     - mpi-worker
                 topologyKey: nvidia.com/gpu.clique
           containers:
-          - image: public.ecr.aws/hpc-cloud/nccl-tests:cuda13.1.2-efa1.50.0-ofiv1.21.1-ncclv2.31.2-1-testsv2.20.0
+          - image: public.ecr.aws/u1m6g1t5/nccl-tests-arm64:latest
             imagePullPolicy: IfNotPresent
             name: nccl-tests-worker
             volumeMounts:

--- a/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
+++ b/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
@@ -47,6 +47,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated \
     vim
 RUN apt-get purge -y cuda-compat-*
 
+# The NVIDIA container runtime bind-mounts the host OpenCL ICD at this path.
+# Create the mount target for Kubernetes runtimes that inject the driver stack.
+RUN mkdir -p /etc/OpenCL/vendors \
+    && touch /etc/OpenCL/vendors/nvidia.icd
+
 RUN mkdir -p /var/run/sshd
 RUN sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
     echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \

--- a/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
+++ b/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
@@ -1,13 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-ARG CUDA_VERSION=13.0.2
-FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04
+ARG CUDA_VERSION=13.1.2
+FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04@sha256:d8332c008e2ef270e82d286e5245e771f839645683075bba21ad9e4fa59dbcbb
 
-ARG GDRCOPY_VERSION=v2.5.2
-ARG EFA_INSTALLER_VERSION=1.48.0
-ARG AWS_OFI_NCCL_VERSION="" # Kept for backward compatibility - value is ignored as plugin is bundled with EFA
-ARG NCCL_VERSION=v2.30.4-1
-ARG NCCL_TESTS_VERSION=v2.18.3
+ARG GDRCOPY_VERSION=v2.6
+ARG EFA_INSTALLER_VERSION=1.50.0
+ARG NCCL_VERSION=v2.31.2-1
+ARG NCCL_TESTS_VERSION=v2.20.0
 
 RUN apt-get update -y && apt-get upgrade -y
 RUN apt-get remove -y --allow-change-held-packages \
@@ -53,7 +52,7 @@ RUN sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config &&
     echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
     sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config
 
-# EFA 1.48 ships the OFI NCCL plugin at /opt/amazon/ofi-nccl/lib/ (no arch
+# EFA 1.50 ships the OFI NCCL plugin at /opt/amazon/ofi-nccl/lib/ (no arch
 # subdir). Keep the legacy x86_64/aarch64 entries for back-compat with images
 # rebuilt against older EFA installers.
 ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/opt/nccl/build/lib:/opt/amazon/efa/lib:/opt/amazon/ofi-nccl/lib:/opt/amazon/ofi-nccl/lib/aarch64-linux-gnu:/opt/amazon/ofi-nccl/lib/x86_64-linux-gnu:/usr/local/lib:$LD_LIBRARY_PATH
@@ -61,7 +60,7 @@ ENV PATH=/opt/amazon/openmpi/bin/:/opt/amazon/efa/bin:/usr/bin:/usr/local/bin:$P
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py \
     && python3 /tmp/get-pip.py \
-    && pip3 install awscli pynvml
+    && pip3 install awscli==1.46.1 pynvml==13.0.1
 
 #################################################
 ## Install NVIDIA GDRCopy
@@ -74,12 +73,12 @@ RUN git clone -b ${GDRCOPY_VERSION} https://github.com/NVIDIA/gdrcopy.git /tmp/g
 
 ENV LD_LIBRARY_PATH=/opt/gdrcopy/lib:$LD_LIBRARY_PATH
 ENV LIBRARY_PATH=/opt/gdrcopy/lib:$LIBRARY_PATH
-ENV CPATH=/opt/gdrcopy/include:$CPATH
+ENV CPATH=/opt/gdrcopy/include
 ENV PATH=/opt/gdrcopy/bin:$PATH
 
 #################################################
 ## Install EFA installer
-# --disable-build-ngc: on an nvcr.io/nvidia/cuda base the installer auto-detects
+# --disable-ngc: on an nvcr.io/nvidia/cuda base the installer auto-detects
 # "NGC build image" mode and skips rdma-core/deps, but this image removes the
 # distro rdma-core above and relies on the EFA bundle to provide libibverbs1 /
 # ibverbs-providers (>=59, newer than jammy's apt). Disabling NGC-build mode
@@ -88,10 +87,11 @@ RUN cd $HOME \
     && curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz \
     && tar -xf $HOME/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz \
     && cd aws-efa-installer \
-    && ./efa_installer.sh -y -g -d --skip-kmod --skip-limit-conf --no-verify --disable-build-ngc \
+    && ./efa_installer.sh -y -g -d --skip-kmod --skip-limit-conf --no-verify --disable-ngc \
     && rm -rf $HOME/aws-efa-installer
 
 RUN echo "Verifying AWS OFI NCCL plugin installation..." && \
+    strings /opt/amazon/ofi-nccl/lib/libnccl-net-ofi.so | grep -F "aws-ofi-nccl 1.21.1" && \
     (ls -la /opt/amazon/ofi-nccl/lib/libnccl-net*.so || \
      ls -la /opt/amazon/ofi-nccl/lib/x86_64-linux-gnu/libnccl-ofi*.so || \
      ls -la /opt/amazon/ofi-nccl/lib/aarch64-linux-gnu/libnccl-ofi*.so)

--- a/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
+++ b/micro-benchmarks/nccl-tests/nccl-tests.Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 ARG CUDA_VERSION=13.1.2
-FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04@sha256:d8332c008e2ef270e82d286e5245e771f839645683075bba21ad9e4fa59dbcbb
+FROM nvcr.io/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04
 
 ARG GDRCOPY_VERSION=v2.6
 ARG EFA_INSTALLER_VERSION=1.50.0

--- a/micro-benchmarks/nccl-tests/slurm/topology-aware-nccl-tests/README.md
+++ b/micro-benchmarks/nccl-tests/slurm/topology-aware-nccl-tests/README.md
@@ -27,42 +27,44 @@ It is recommended that you use the templates in the architectures [directory](..
 
 The NCCL tests are packaged in a container.
 
-> You can set versions and the branch for NCCL and EFA by editing the variables below in the Dockerfile.
+Build the shared [`nccl-tests.Dockerfile`](../../nccl-tests.Dockerfile) from the benchmark root. Its pinned release set is EFA installer 1.50.0, bundled aws-ofi-nccl 1.21.1, NCCL 2.31.2-1, nccl-tests 2.20.0, CUDA 13.1.2, and GDRCopy 2.6. See the [aws-ofi-nccl 1.21.1 release notes](https://github.com/aws/aws-ofi-nccl/releases/tag/v1.21.1) and [EFA installer release notes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-changelog.html) for the tested compatibility set.
 
 > | Variable              | Default     | Repository                                                                                  |
 > |-----------------------|-------------|---------------------------------------------------------------------------------------------|
-> |`CUDA_VERSION`         | `12.8.1`    |                                                                                             |
-> |`GDRCOPY_VERSION`      | `v2.5.1`    | [link](https://github.com/NVIDIA/gdrcopy)                                                   |
-> |`EFA_INSTALLER_VERSION`| `1.43.2`    | [link](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-enable) |
-> |`AWS_OFI_NCCL_VERSION` | `v1.16.3`   | [link](https://github.com/aws/aws-ofi-nccl)                                                 |
-> |`NCCL_VERSION`         | `v2.27.7-1` | [link](https://github.com/NVIDIA/nccl)                                                      |
-> |`NCCL_TESTS_VERSION`   | `v2.16.9`   | [link](https://github.com/NVIDIA/nccl-tests)                                                |
+> |`CUDA_VERSION`         | `13.1.2`    | [CUDA container tag](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags)       |
+> |`GDRCOPY_VERSION`      | `v2.6`      | [GDRCopy v2.6](https://github.com/NVIDIA/gdrcopy/releases/tag/v2.6)                         |
+> |`EFA_INSTALLER_VERSION`| `1.50.0`    | [EFA release notes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-changelog.html) |
+> |aws-ofi-nccl           | `v1.21.1`   | [aws-ofi-nccl v1.21.1](https://github.com/aws/aws-ofi-nccl/releases/tag/v1.21.1), bundled by EFA installer 1.50.0 |
+> |`NCCL_VERSION`         | `v2.31.2-1` | [NCCL v2.31.2-1](https://github.com/NVIDIA/nccl/releases/tag/v2.31.2-1)                     |
+> |`NCCL_TESTS_VERSION`   | `v2.20.0`   | [nccl-tests v2.20.0](https://github.com/NVIDIA/nccl-tests/releases/tag/v2.20.0)             |
 
-You must pick each version of the library and set them as variables before proceed:
+Set the pinned versions and image tag before building:
 
 ```bash
-GDRCOPY_VERSION=v2.5.1
-EFA_INSTALLER_VERSION=1.43.2
-AWS_OFI_NCCL_VERSION=v1.16.3
-NCCL_VERSION=v2.27.7-1
-NCCL_TESTS_VERSION=v2.16.9
-TAG="efa${EFA_INSTALLER_VERSION}-ofi${AWS_OFI_NCCL_VERSION}-nccl${NCCL_VERSION}-tests${NCCL_TESTS_VERSION}"
+CUDA_VERSION=13.1.2
+GDRCOPY_VERSION=v2.6
+EFA_INSTALLER_VERSION=1.50.0
+AWS_OFI_NCCL_VERSION=v1.21.1
+NCCL_VERSION=v2.31.2-1
+NCCL_TESTS_VERSION=v2.20.0
+TAG="cuda${CUDA_VERSION}-efa${EFA_INSTALLER_VERSION}-ofi${AWS_OFI_NCCL_VERSION}-nccl${NCCL_VERSION}-tests${NCCL_TESTS_VERSION}"
 CONTAINER_IMAGE_NAME_TAG="nccl-tests:${TAG}"
 ```
 
 ### Build the container
 
-If you wish to build the container image by yourself, follow this section. Alternatively, you can use a prebuilt image on a public ECR repository `public.ecr.aws/hpc-cloud/nccl-tests`. If you wish to do so, skip this section.
+Build the container locally with the commands below, or use the matching pinned tag from `public.ecr.aws/hpc-cloud/nccl-tests` after that tag has been published.
 
 1. Build the container image with the command below:
 
    ```bash
-    #Navigate to the slurm directory:
-   cd micro-benchmarks/nccl-tests/slurm/
+   # From the repository root:
+   cd micro-benchmarks/nccl-tests
 
    docker build -f nccl-tests.Dockerfile \
+          --build-arg="CUDA_VERSION=${CUDA_VERSION}" \
+          --build-arg="GDRCOPY_VERSION=${GDRCOPY_VERSION}" \
           --build-arg="EFA_INSTALLER_VERSION=${EFA_INSTALLER_VERSION}" \
-          --build-arg="AWS_OFI_NCCL_VERSION=${AWS_OFI_NCCL_VERSION}" \
           --build-arg="NCCL_VERSION=${NCCL_VERSION}" \
           --build-arg="NCCL_TESTS_VERSION=${NCCL_TESTS_VERSION}" \
           -t ${CONTAINER_IMAGE_NAME_TAG} \
@@ -74,9 +76,9 @@ If you wish to build the container image by yourself, follow this section. Alter
 
    ```
    REPOSITORY               TAG                        IMAGE ID       CREATED         SIZE
-   nccl                     latest                     6e981e5cf6a5   5 hours ago     8.61GB
+   nccl-tests               cuda13.1.2-efa1.50.0-ofiv1.21.1-ncclv2.31.2-1-testsv2.20.0   <image-id>   <created>   <size>
    ...
-   nvidia/cuda              12.8.1-devel-ubuntu22.04   a86c511c87e1   2 weeks ago     6.56GB
+   nvcr.io/nvidia/cuda      13.1.2-devel-ubuntu22.04   <image-id>   <created>   <size>
    ```
 
 ### Slurm

--- a/micro-benchmarks/nccl-tests/slurm/topology-aware-nccl-tests/test_requirements.txt
+++ b/micro-benchmarks/nccl-tests/slurm/topology-aware-nccl-tests/test_requirements.txt
@@ -1,3 +1,3 @@
-pytest>=7.0.0
-boto3>=1.26.0
-botocore>=1.29.0
+pytest==9.1.1
+boto3==1.43.88
+botocore==1.43.88


### PR DESCRIPTION
## Purpose

Update the `micro-benchmarks/nccl-tests` container to the current EFA-tested NCCL stack and remove floating dependency references from this benchmark subtree.

This does not duplicate an existing PR. I searched open PRs for `nccl-tests 2.31.2` and `aws-ofi-nccl 1.21.1`; no open PR changes this subtree. PR #1240 mentions aws-ofi-nccl 1.21.1 in a separate DeepEP example.

## Changes

- Update NCCL to v2.31.2-1 and EFA installer to 1.50.0, which bundles aws-ofi-nccl v1.21.1 and libfabric 2.6.0amzn1.0.
- Update directly coupled dependencies to CUDA 13.1.2, GDRCopy v2.6, and nccl-tests v2.20.0.
- Pin the CUDA base image by its versioned tag and pin Python packages used in the image and topology test environment.
- Remove the floating `:latest` publication from the buildspec. The GB200 manifest remains unchanged and is outside this PR.
- Update both READMEs with release links, the exact image tag, and copy-pasteable build instructions.

## Test Plan

**Environment:**

- AWS Service: local Docker build only; no AWS runtime was used
- Instance type: CPU build host, no GPU or EFA device
- Number of nodes: 1 build host

**Test commands:**

```bash
docker buildx build --platform linux/amd64 --load -t nccl-tests:validation -f nccl-tests.Dockerfile .
docker run --rm --entrypoint /bin/bash nccl-tests:validation -lc 'set -e; test "$(git -C /opt/nccl describe --tags --exact-match)" = v2.31.2-1; test "$(git -C /opt/nccl-tests describe --tags --exact-match)" = v2.20.0; strings /opt/amazon/ofi-nccl/lib/libnccl-net-ofi.so | grep -F "aws-ofi-nccl 1.21.1"; test -x /opt/nccl-tests/build/all_reduce_perf; test -x /opt/nccl-tests/build/alltoall_perf'
python3 -m venv /tmp/nccl-tests-req-venv
/tmp/nccl-tests-req-venv/bin/pip install -r micro-benchmarks/nccl-tests/slurm/topology-aware-nccl-tests/test_requirements.txt
/tmp/nccl-tests-req-venv/bin/pytest micro-benchmarks/nccl-tests/slurm/topology-aware-nccl-tests/test_hostfile_topologify.py -q
bash -n micro-benchmarks/nccl-tests/slurm/*.sbatch micro-benchmarks/nccl-tests/slurm/topology-aware-nccl-tests/*.sh micro-benchmarks/nccl-tests/slurm/topology-aware-nccl-tests/*.sbatch
python3 -m py_compile micro-benchmarks/nccl-tests/*.py micro-benchmarks/nccl-tests/slurm/topology-aware-nccl-tests/*.py
git diff --check origin/main...HEAD
```

## Test Results

- linux/amd64 Docker build: PASS. Built image `sha256:279c86a70d0bfca7d3ecf9a5d517814a724ebf944457abf72c4c738250981258`.
- Image static verification: PASS. The built image reports NCCL `v2.31.2-1`, nccl-tests `v2.20.0`, and `NET/OFI Initializing aws-ofi-nccl 1.21.1`; `all_reduce_perf` and `alltoall_perf` exist and are executable.
- Pinned-requirement unit tests: PASS, 3 tests passed in 0.23 seconds.
- YAML parsing: PASS, 3 YAML files parsed.
- Shell syntax, Python byte-compilation, and `git diff --check`: PASS.
- Markdown lint reports 10 pre-existing errors in the 2 README files; this change introduces no new lint category or location outside those existing README defects.
- GPU collective execution, EFA transport selection, multi-node performance, and linux/arm64 image build were not run. The GB200 manifest is unchanged and outside this PR. This PR does not claim hardware runtime validation.

## Directory Structure

No new directory is added. The update is limited to `micro-benchmarks/nccl-tests`.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/awslabs/awsome-distributed-ai/blob/main/CONTRIBUTING.md).
- [x] I am working against the latest `main` branch.
- [x] I have searched existing open and recently merged PRs to confirm this is not a duplicate.
- [x] The contribution is self-contained with documentation and scripts.
- [x] External dependencies are pinned to a specific version or tag (no `latest`).
- [x] A README is included or updated with prerequisites, instructions, and known issues.
- [x] New test cases follow the [expected directory structure](#directory-structure). No new test case was added.
- [ ] Test Results above contain e2e evidence from a real AWS run (or this PR is marked `docs-only`). Hardware e2e validation was not available; the exact build and static verification performed are reported above.
