### PR TITLE
feat(deepep-efa): NVIDIA Dynamo DeepEP-V2 MoE all-to-all over EFA (NCCL-GIN CPU-proxy)

### DIFF
--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/.dockerignore
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/.dockerignore
@@ -1,0 +1,7 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+# .gitignore does NOT apply to the Docker build context, so without this file the
+# gitignored setup/env_vars (your ECR URI) is uploaded to the daemon/CI builder on
+# every `docker build .` even though the Dockerfile COPYs named files (never `COPY . .`).
+# Keep it excluded from the context; benchmarks/raw/ is measurement output, never an input.
+setup/env_vars
+benchmarks/raw/

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/.dockerignore
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/.dockerignore
@@ -5,3 +5,4 @@
 # Keep it excluded from the context; benchmarks/raw/ is measurement output, never an input.
 setup/env_vars
 benchmarks/raw/
+*.log

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/.gitignore
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/.gitignore
@@ -1,0 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+setup/env_vars
+benchmarks/raw/
+*.log

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/Dockerfile
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/Dockerfile
@@ -1,0 +1,169 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+#
+# NVIDIA Dynamo (frontend + dynamo.vllm) serving DeepEP-V2 MoE all-to-all over AWS EFA
+# (NCCL-GIN CPU-proxy). NGC-from-scratch. This is the vLLM-DeepEP-V2 substrate (identical to
+# ../../vllm/deepep-v2-efa through Layer 5b) plus a Dynamo serving front (Layer 5c). DeepEP's
+# default NVSHMEM/IBGDA transport is dead on EFA; this uses aws-ofi-nccl's GIN CPU-proxy
+# (NCCL_GIN_TYPE=2). Build logic lives in setup_deepep_v2_efa.sh (COPY'd, not curled) so it is
+# in-tree + reviewable. The DeepEP _C.so is built IN-POD on first boot (recipe/build_deepep.sh)
+# — it needs a live CUDA context the build sandbox lacks.
+#
+#   setup/build-push.sh builds + pushes ${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} (setup/env_vars);
+#   manual equivalent: DOCKER_BUILDKIT=1 docker build -t <registry>/dynamo-deepep-v2-efa:<tag> .
+#
+ARG CUDA_VER=13.0.0                                   # cu13 to match the torch 2.11+cu130 ABI DeepEP links
+FROM nvcr.io/nvidia/cuda:${CUDA_VER}-devel-ubuntu22.04
+
+LABEL org.opencontainers.image.description="NVIDIA Dynamo serving DeepEP-V2 MoE all-to-all over AWS EFA (NCCL-GIN CPU-proxy)"
+LABEL org.opencontainers.image.licenses="MIT-0"
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+
+# ---- Layer 1: system + build deps -------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential autoconf automake libtool pkg-config git curl wget ca-certificates \
+      libnuma-dev libhwloc-dev python3 python3-pip python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---- Layer 2: AWS EFA (public installer; pinned, verified fresher than 1.48 per freshness rule) ----
+# --disable-ngc: this NGC base ships /opt/nvidia/nvidia_entrypoint.sh, which trips the
+# installer's NGC auto-detect and silently reroutes it down the libnccl-ofi-ngc path.
+# We build aws-ofi-nccl from source ourselves (Layer 4), so force the normal install —
+# same explicit choice as the sibling sglang/dsr1-deepep-efa and vllm/dsv3-uccl-nixl samples.
+ARG EFA_INSTALLER_VER=1.49.0                          # pin — no 'latest' (the stack under test)
+RUN apt-get update \
+    && curl -fsSL https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VER}.tar.gz | tar -xzf - -C /tmp \
+    && cd /tmp/aws-efa-installer && ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify --disable-ngc \
+    && echo "${EFA_INSTALLER_VER}" > /opt/efa-installer.version \
+    && rm -rf /tmp/aws-efa-installer /var/lib/apt/lists/*
+ENV PATH=/opt/amazon/efa/bin:/opt/amazon/openmpi/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/amazon/efa/lib:/opt/amazon/openmpi/lib:${LD_LIBRARY_PATH:-}
+
+# ---- Layer 3: torch cu13 stack (pinned; nccl-cu13 2.30.4 carries the GIN/LSA device symbols) ----
+ARG TORCH_SPEC="torch==2.11.0"                        # DeepEP _C.so links this exact ABI
+ARG TORCH_INDEX="https://download.pytorch.org/whl/cu130"
+ARG NVIDIA_NCCL_CU13="2.30.4"                         # 2.28.x lacks the GIN/LSA symbols the plugin needs
+ARG NVSHMEM_CU13="3.6.5"
+RUN pip3 install --no-cache-dir --index-url "${TORCH_INDEX}" "${TORCH_SPEC}" \
+    && pip3 install --no-cache-dir "nvidia-nccl-cu13==${NVIDIA_NCCL_CU13}" "nvidia-nvshmem-cu13==${NVSHMEM_CU13}" ninja
+# ninja is baked here EXPLICITLY (build_deepep.sh device-links the DeepEP extension, which
+# requires it): first pod boot must not depend on PyPI egress — private-subnet/air-gapped
+# clusters would otherwise fail inside a compile step instead of a clear network error.
+# resolve the pip nccl onto the linker path (dynamic — never hardcode python3.NN) so it wins over any system libnccl
+RUN NCCL_ROOT=$(python3 -c "import nvidia.nccl, pathlib; print(pathlib.Path(nvidia.nccl.__path__[0]))") \
+    && echo "$NCCL_ROOT/lib" > /etc/ld.so.conf.d/00-pip-nccl.conf && ldconfig \
+    && ldconfig -p | grep "libnccl.so.2 " | head -1 | grep -q "$NCCL_ROOT/lib"   # assert the pinned NCCL resolves FIRST (2.28.x lacks the GIN/LSA symbols the plugin needs)
+
+# ---- Layer 3b: gdrcopy userspace (PUBLIC: github.com/NVIDIA/gdrcopy) ----
+# aws-ofi-nccl's GIN path REQUIRES gdrapi.h at configure time — without it the plugin
+# compiles with "GDRCopy support not available", nccl_ofi_gin_init fails at serve, and
+# DeepEP's ElasticBuffer asserts ginType==NCCL_GIN_TYPE_NONE. Userspace 2.5.2 on a
+# gdrdrv-2.4 host is exactly the pairing OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1 (#1351) fixes.
+# gdrcopy v2.5.2 == commit c91ad9f: pin the commit, not the tag (a bare tag is a moving ref
+# upstream can re-point — every other dep here is SHA-pinned).
+ARG GDRCOPY_SHA=c91ad9f178e5fb729fc5b6dc62a77c3bb364d6c9
+RUN git clone https://github.com/NVIDIA/gdrcopy.git /tmp/gdrcopy \
+    && cd /tmp/gdrcopy && git fetch origin ${GDRCOPY_SHA} && git checkout ${GDRCOPY_SHA} \
+    && make prefix=/usr/local lib lib_install && ldconfig \
+    && rm -rf /tmp/gdrcopy
+
+# ---- Layer 4: aws-ofi-nccl GIN + DeepEP-V2 source (in-tree script, COPY'd not curled) ----
+COPY setup_deepep_v2_efa.sh /opt/setup_deepep_v2_efa.sh
+ARG AWS_OFI_NCCL_SHA=9c44d34476f90ddbf4a12d0ac4fc412d46bd8ab4
+ARG AWS_OFI_NCCL_PR=1351
+ARG AWS_OFI_NCCL_PR_SHA=c2e773dfb2c75b765b3415f8ffd1b47e7c239a7b  # IMMUTABLE PR#1351 head (FORCED_PCIE param; a bare refs/pull/N/head is a moving ref)
+ARG DEEPEP_SHA=b306af06afd412c88e51e71802951606e40b7358
+ARG DEEPEP_PR=612
+ARG DEEPEP_PR_SHA=28d1f7fb173f728be51632ce0026fea23243e350
+RUN chmod +x /opt/setup_deepep_v2_efa.sh \
+    && AWS_OFI_NCCL_SHA=${AWS_OFI_NCCL_SHA} AWS_OFI_NCCL_PR=${AWS_OFI_NCCL_PR} AWS_OFI_NCCL_PR_SHA=${AWS_OFI_NCCL_PR_SHA} \
+       DEEPEP_SHA=${DEEPEP_SHA} DEEPEP_PR=${DEEPEP_PR} DEEPEP_PR_SHA=${DEEPEP_PR_SHA} \
+       /opt/setup_deepep_v2_efa.sh
+ENV LD_LIBRARY_PATH=/opt/aws-ofi-nccl/lib:${LD_LIBRARY_PATH}
+
+# ---- Layer 5: vLLM (pinned wheel = PR#41183's merge commit — the first, and only measured-working, deepep_v2 backend) ----
+# The wheel FILENAME is derived from the per-commit index at build time, so bumping
+# VLLM_SHA ALONE is sufficient (hardcoding the filename would embed the SHA twice and a
+# lone bump 404s).
+# NOTE: wheels.vllm.ai nightly wheels are garbage-collected upstream, so this pin has a
+# shelf life independent of this repo; the fail-loud check below names that cause.
+# Pin = e2f993dc4 = the merge commit of vLLM PR#41183 (the commit that ADDED the deepep_v2
+# backend, DeepEPV2All2AllManager) = 0.22.1rc1.dev283. This is the EXACT substrate the
+# benchmarks/ tables were measured on, so a rebuild reproduces them. It is served EAGER
+# (--enforce-eager, the shipped default): non-eager at this pin crashes deterministically
+# in profile_run and needs the #52632 empty-ExpertTokensMetadata guard, which is NOT in
+# this pin — see README "eager vs non-eager".
+# Why not a newer pin: vLLM 0.26 (the line that carries #52632) regresses the deepep_v2
+# combine on this exact DeepEP _C.so / EFA substrate — DP16/EP16 faults
+# `CUDA_ERROR_LAUNCH_FAILED (719)` in profile_run/determine_available_memory during KV-cache
+# sizing (measured 2026-09-04, eager AND non-eager; the standalone kernel-test still passes,
+# so the fault is 0.26's DeepEP-V2 driver, not the kernels). e2f993dc4 is the newest vLLM
+# proven to serve deepep_v2 DP16/EP16 on EFA, so the pin stays here until a newer line is
+# re-measured green on this substrate.
+ARG VLLM_SHA=e2f993dc4116ba96ea10ec40b7bd2ee45b27b2b8
+RUN WHEEL_HREF=$(curl -fsSL "https://wheels.vllm.ai/${VLLM_SHA}/vllm/" | grep -oE 'href="[^"]*manylinux[^"]*x86_64\.whl"' | head -1 | cut -d'"' -f2) \
+    && { [ -n "$WHEEL_HREF" ] || { echo "FATAL: no x86_64 vllm wheel indexed for ${VLLM_SHA} (bad SHA, or nightly wheel garbage-collected upstream)"; exit 1; }; } \
+    && pip3 install --no-cache-dir "https://wheels.vllm.ai/${VLLM_SHA}/$(basename "$WHEEL_HREF")" \
+    && python3 -c "import vllm; print('vllm', vllm.__version__)"
+
+# ---- Layer 5b: re-pin the ABI-critical cu13 libs AFTER the last pip layer (order matters) ----
+# The vLLM wheel's dependency resolution drags nvidia-nccl-cu13 back down to torch's 2.28.9
+# (and nvshmem to 3.4.5) — silently, into the SAME directory, so the Layer-3 linker-precedence
+# assert stays green while the GIN/LSA device symbols vanish and DeepEP's nccl.cu no longer
+# compiles in-pod. Any pip layer added later must keep this re-pin LAST.
+RUN pip3 install --no-cache-dir --no-deps --force-reinstall \
+      "nvidia-nccl-cu13==${NVIDIA_NCCL_CU13}" "nvidia-nvshmem-cu13==${NVSHMEM_CU13}" \
+    && NCCL_ROOT=$(python3 -c "import nvidia.nccl, pathlib; print(pathlib.Path(nvidia.nccl.__path__[0]))") \
+    && grep -rq ncclGetLsaDevicePointer "$NCCL_ROOT/include/" \
+    && [ "$(nm -D "$NCCL_ROOT/lib/libnccl.so.2" | grep -c ncclGetLsaDevicePointer)" -ge 1 ]  # GIN/LSA symbols present (2.28.x lacks them)
+
+# ---- Layer 5c: NVIDIA Dynamo serving front (--no-deps: this is the ONLY delta vs the vLLM twin) ----
+# This image is the vLLM-DeepEP-V2 substrate (Layers 1-5b, byte-identical to ../../vllm/deepep-v2-efa)
+# with Dynamo's serving front added on top. dynamo.vllm wraps the SAME vLLM engine (it forwards every
+# unknown CLI flag straight into vLLM's AsyncEngineArgs), so nothing about the DeepEP-V2/EFA transport
+# changes — only an OpenAI-compatible frontend + a DP/EP-aware worker wrapper are added.
+#   --no-deps is LOAD-BEARING, not caution: `ai-dynamo==1.3.1` declares `vllm[...]==0.23.0` as a
+#   dependency (the [vllm] extra). Without --no-deps, pip would pull the 0.23.0 RELEASE wheel and
+#   overwrite the pinned VLLM_SHA build from Layer 5 (which also drags nvidia-nccl-cu13 back to torch's
+#   2.28.x, undoing Layer 5b). With --no-deps, ai-dynamo (pure-python, py3-none-any) + ai-dynamo-runtime
+#   (compiled cp310-abi3, and it carries NO vllm pin at all — it is the vLLM-independent Rust core)
+#   install their own files ONLY; the sole real deps (pydantic, uvloop) are already present from the
+#   vLLM wheel. Both packages are PEP-420 namespace packages under dynamo/, so the compiled core and the
+#   pure-python components union cleanly with no dynamo/__init__.py shadowing.
+#   1.3.1 (not 1.4.x): the pinned vLLM substrate is 0.22 (e2f993dc4, Layer 5). dynamo.vllm is a thin
+#   arg-forwarding wrapper (it delegates every unknown flag to vLLM's own AsyncEngineArgs.add_cli_args
+#   and constructs AsyncLLM directly), so the version that matters is the vLLM API surface its Python was
+#   authored against. 1.3.1 targets 0.23.0 — ONE minor from the 0.22 substrate, the closest released
+#   dynamo.vllm surface (1.2.1→0.20.1 is older AND further; 1.4.x→0.26.0 targets the line whose deepep_v2
+#   combine regresses here). Verified offline (vllm git tree @ e2f993dc4) that every vLLM module path
+#   dynamo.vllm.main imports exists at this pin — including the vllm/utils.py→vllm/utils/ PACKAGE split
+#   (vllm.utils.system_utils, vllm.utils.hashing) that 1.3.1's Python assumes; the 0.22 substrate already
+#   carries the post-split layout.
+#   The Layer-5c assert imports `dynamo.vllm.MAIN` — the real serve entrypoint (`python3 -m dynamo.vllm`),
+#   NOT bare `dynamo.vllm` (whose __init__ only sets __version__ and imports NO vLLM, so it would gate
+#   nothing). main.py pulls the full serve-path vLLM API surface (vllm.config, vllm.v1.engine.async_llm,
+#   vllm.usage.usage_lib, vllm.distributed.kv_events, vllm.v1.metrics.prometheus, and transitively the
+#   ~22 vllm.* paths of its dynamo.vllm.* closure) at MODULE scope, while main() stays behind
+#   `if __name__ == "__main__"` — so the import resolves the 0.22↔1.3.1 API contract WITHOUT running the
+#   engine, parsing argv, or needing a GPU (vLLM imports clean on a CPU-only buildkit box). This is the
+#   build-time gate on 0.22↔1.3.1 serve-path compatibility: the build FAILS LOUD on any drifted symbol,
+#   catching an incompatibility in ~5 min at build instead of ~40 min into a live pod. (main.py's only
+#   non-vLLM third-party top-level imports — huggingface_hub, prometheus_client, uvloop — are already
+#   provided by the vLLM wheel, so --no-deps does not false-fail this gate.)
+ARG AI_DYNAMO_VER=1.3.1
+RUN pip3 install --no-cache-dir --no-deps \
+      "ai-dynamo-runtime==${AI_DYNAMO_VER}" "ai-dynamo==${AI_DYNAMO_VER}" \
+    && python3 -c "import dynamo.vllm.main, dynamo.frontend; print('dynamo.vllm.main + dynamo.frontend import OK — serve-path vLLM API resolved against the pinned wheel')" \
+    && NCCL_ROOT=$(python3 -c "import nvidia.nccl, pathlib; print(pathlib.Path(nvidia.nccl.__path__[0]))") \
+    && [ "$(nm -D "$NCCL_ROOT/lib/libnccl.so.2" | grep -c ncclGetLsaDevicePointer)" -ge 1 ]  # re-assert Layer 5b survived the dynamo install (must, given --no-deps)
+
+# ---- Layer 6: the serve/build scripts (LAST — script iteration never invalidates heavy layers) ----
+COPY recipe/build_deepep.sh /opt/build_deepep.sh
+COPY recipe/serve.sh /opt/serve.sh
+COPY recipe/run-kernel-test.sh /opt/run-kernel-test.sh
+COPY recipe/benchmark_probe.py /opt/benchmark_probe.py
+COPY recipe/benchmark.sh /opt/benchmark.sh
+RUN chmod +x /opt/build_deepep.sh /opt/serve.sh /opt/run-kernel-test.sh /opt/benchmark.sh
+
+# The segfault-fix env (EP_REUSE_NCCL_COMM=0) + proxy-Gin contract are set by recipe/serve.sh at launch.
+CMD ["/bin/bash", "-lc", "echo 'run: /opt/serve.sh {leader|worker} <ip>; /opt/build_deepep.sh runs once on first boot'; sleep infinity"]

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/Dockerfile
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/Dockerfile
@@ -72,12 +72,10 @@ COPY setup_deepep_v2_efa.sh /opt/setup_deepep_v2_efa.sh
 ARG AWS_OFI_NCCL_SHA=9c44d34476f90ddbf4a12d0ac4fc412d46bd8ab4
 ARG AWS_OFI_NCCL_PR=1351
 ARG AWS_OFI_NCCL_PR_SHA=c2e773dfb2c75b765b3415f8ffd1b47e7c239a7b  # IMMUTABLE PR#1351 head (FORCED_PCIE param; a bare refs/pull/N/head is a moving ref)
-ARG DEEPEP_SHA=b306af06afd412c88e51e71802951606e40b7358
-ARG DEEPEP_PR=612
-ARG DEEPEP_PR_SHA=28d1f7fb173f728be51632ce0026fea23243e350
+ARG DEEPEP_SHA=97d8f9bcc1be31e9036db2ab591ef9b9f4e38619   # amazon-contributing/DeepEP@main, 2026-09-03 (the canonical V2/GIN source)
 RUN chmod +x /opt/setup_deepep_v2_efa.sh \
     && AWS_OFI_NCCL_SHA=${AWS_OFI_NCCL_SHA} AWS_OFI_NCCL_PR=${AWS_OFI_NCCL_PR} AWS_OFI_NCCL_PR_SHA=${AWS_OFI_NCCL_PR_SHA} \
-       DEEPEP_SHA=${DEEPEP_SHA} DEEPEP_PR=${DEEPEP_PR} DEEPEP_PR_SHA=${DEEPEP_PR_SHA} \
+       DEEPEP_SHA=${DEEPEP_SHA} \
        /opt/setup_deepep_v2_efa.sh
 ENV LD_LIBRARY_PATH=/opt/aws-ofi-nccl/lib:${LD_LIBRARY_PATH}
 

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/Dockerfile
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/Dockerfile
@@ -75,6 +75,11 @@ RUN chmod +x /opt/setup_deepep_v2_efa.sh \
     && AWS_OFI_NCCL_REF=${AWS_OFI_NCCL_REF} DEEPEP_SHA=${DEEPEP_SHA} \
        /opt/setup_deepep_v2_efa.sh
 ENV LD_LIBRARY_PATH=/opt/aws-ofi-nccl/lib:${LD_LIBRARY_PATH}
+# nvidia-container-runtime injects /dev/gdrdrv only when NVIDIA_GDRCOPY=enabled is set; required on
+# the raw `docker run` path the README offers (k8s uses privileged instead). Same bake as the
+# canonical deepep-v2-benchmark/deepep.Dockerfile. (Comment sits ABOVE the ENV: BuildKit's key=value
+# parser rejects an inline `#` token on ENV lines.)
+ENV NVIDIA_GDRCOPY=enabled
 
 # ---- Layer 5: vLLM (pinned wheel = PR#41183's merge commit — the first, and only measured-working, deepep_v2 backend) ----
 # The wheel FILENAME is derived from the per-commit index at build time, so bumping
@@ -110,20 +115,25 @@ RUN pip3 install --no-cache-dir --no-deps --force-reinstall \
       "nvidia-nccl-cu13==${NVIDIA_NCCL_CU13}" "nvidia-nvshmem-cu13==${NVSHMEM_CU13}" \
     && NCCL_ROOT=$(python3 -c "import nvidia.nccl, pathlib; print(pathlib.Path(nvidia.nccl.__path__[0]))") \
     && grep -rq ncclGetLsaDevicePointer "$NCCL_ROOT/include/" \
-    && [ "$(nm -D "$NCCL_ROOT/lib/libnccl.so.2" | grep -c ncclGetLsaDevicePointer)" -ge 1 ]  # GIN/LSA symbols present (2.28.x lacks them)
+    && [ "$(nm -D "$NCCL_ROOT/lib/libnccl.so.2" | grep -c ncclGetLsaDevicePointer)" -ge 1 ] \
+    && python3 -c "import torch; assert torch.__version__ == '2.11.0+cu130', f'torch drifted: {torch.__version__} != 2.11.0+cu130'"  # GIN/LSA symbols present (2.28.x lacks them) + the torch build every ABI comment in this file assumes (the vLLM wheel keeps 2.11.0+cu130 only via PEP 440's local-version rule, so assert it rather than trust it)
 
 # ---- Layer 5c: NVIDIA Dynamo serving front (--no-deps: this is the ONLY delta vs the vLLM twin) ----
 # This image is the vLLM-DeepEP-V2 substrate (Layers 1-5b, byte-identical to ../../vllm/deepep-v2-efa)
 # with Dynamo's serving front added on top. dynamo.vllm wraps the SAME vLLM engine (it forwards every
 # unknown CLI flag straight into vLLM's AsyncEngineArgs), so nothing about the DeepEP-V2/EFA transport
 # changes — only an OpenAI-compatible frontend + a DP/EP-aware worker wrapper are added.
-#   --no-deps is LOAD-BEARING, not caution: `ai-dynamo==1.3.1` declares `vllm[...]==0.23.0` as a
-#   dependency (the [vllm] extra). Without --no-deps, pip would pull the 0.23.0 RELEASE wheel and
-#   overwrite the pinned VLLM_SHA build from Layer 5 (which also drags nvidia-nccl-cu13 back to torch's
-#   2.28.x, undoing Layer 5b). With --no-deps, ai-dynamo (pure-python, py3-none-any) + ai-dynamo-runtime
-#   (compiled cp310-abi3, and it carries NO vllm pin at all — it is the vLLM-independent Rust core)
-#   install their own files ONLY; the sole real deps (pydantic, uvloop) are already present from the
-#   vLLM wheel. Both packages are PEP-420 namespace packages under dynamo/, so the compiled core and the
+#   --no-deps is LOAD-BEARING, not caution — but for the unconditional dependency set, not the vLLM
+#   extra: `ai-dynamo==1.3.1` declares `vllm[...]==0.23.0` only behind the `[vllm]` extra, and a bare
+#   `pip install ai-dynamo` never resolves an extra, so the pinned VLLM_SHA wheel from Layer 5 is not
+#   at risk from that with or without this flag. What --no-deps prevents is pip re-resolving
+#   ai-dynamo's nine UNCONDITIONAL deps (ai-dynamo-runtime, aiohttp, kubernetes, msgspec,
+#   prometheus-client, pyzmq, transformers>=4.56, typing-extensions, zstandard) OVER the versions the
+#   pinned vLLM wheel installed — transformers / prometheus-client / msgspec / pyzmq in particular.
+#   With --no-deps, ai-dynamo (pure-python, py3-none-any) + ai-dynamo-runtime (compiled cp310-abi3;
+#   the vLLM-independent Rust core, no vllm pin at all) install their own files ONLY; their real
+#   runtime needs (pydantic, uvloop — ai-dynamo-runtime's deps) are already present from the vLLM
+#   wheel. Both packages are PEP-420 namespace packages under dynamo/, so the compiled core and the
 #   pure-python components union cleanly with no dynamo/__init__.py shadowing.
 #   1.3.1 (not 1.4.x): the pinned vLLM substrate is 0.22 (e2f993dc4, Layer 5). dynamo.vllm is a thin
 #   arg-forwarding wrapper (it delegates every unknown flag to vLLM's own AsyncEngineArgs.add_cli_args
@@ -136,7 +146,9 @@ RUN pip3 install --no-cache-dir --no-deps --force-reinstall \
 #   carries the post-split layout.
 #   The Layer-5c assert imports `dynamo.vllm.MAIN` — the real serve entrypoint (`python3 -m dynamo.vllm`),
 #   NOT bare `dynamo.vllm` (whose __init__ only sets __version__ and imports NO vLLM, so it would gate
-#   nothing). main.py pulls the full serve-path vLLM API surface (vllm.config, vllm.v1.engine.async_llm,
+#   nothing) — and `dynamo.frontend.MAIN` for the same reason: dynamo/frontend/__init__.py is a bare
+#   _version shim, while frontend/main.py is what `python3 -m dynamo.frontend` (serve.sh) actually runs.
+#   main.py pulls the full serve-path vLLM API surface (vllm.config, vllm.v1.engine.async_llm,
 #   vllm.usage.usage_lib, vllm.distributed.kv_events, vllm.v1.metrics.prometheus, and transitively the
 #   ~22 vllm.* paths of its dynamo.vllm.* closure) at MODULE scope, while main() stays behind
 #   `if __name__ == "__main__"` — so the import resolves the 0.22↔1.3.1 API contract WITHOUT running the
@@ -148,7 +160,7 @@ RUN pip3 install --no-cache-dir --no-deps --force-reinstall \
 ARG AI_DYNAMO_VER=1.3.1
 RUN pip3 install --no-cache-dir --no-deps \
       "ai-dynamo-runtime==${AI_DYNAMO_VER}" "ai-dynamo==${AI_DYNAMO_VER}" \
-    && python3 -c "import dynamo.vllm.main, dynamo.frontend; print('dynamo.vllm.main + dynamo.frontend import OK — serve-path vLLM API resolved against the pinned wheel')" \
+    && python3 -c "import dynamo.vllm.main, dynamo.frontend.main; print('dynamo.vllm.main + dynamo.frontend.main import OK — serve-path vLLM API resolved against the pinned wheel')" \
     && NCCL_ROOT=$(python3 -c "import nvidia.nccl, pathlib; print(pathlib.Path(nvidia.nccl.__path__[0]))") \
     && [ "$(nm -D "$NCCL_ROOT/lib/libnccl.so.2" | grep -c ncclGetLsaDevicePointer)" -ge 1 ]  # re-assert Layer 5b survived the dynamo install (must, given --no-deps)
 

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/Dockerfile
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # --disable-ngc: this NGC base ships /opt/nvidia/nvidia_entrypoint.sh, which trips the
 # installer's NGC auto-detect and silently reroutes it down the libnccl-ofi-ngc path.
 # We build aws-ofi-nccl from source ourselves (Layer 4), so force the normal install —
-# same explicit choice as the sibling sglang/dsr1-deepep-efa and vllm/dsv3-uccl-nixl samples.
+# same explicit choice as the sibling vllm/dsv3-uccl-nixl sample (sglang/dsr1-deepep-efa
+# runs the installer without it).
 ARG EFA_INSTALLER_VER=1.50.0                          # pin, no 'latest'; matches micro-benchmarks/expert-parallelism/deepep-v2-benchmark/deepep.Dockerfile
 RUN apt-get update \
     && curl -fsSL https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VER}.tar.gz | tar -xzf - -C /tmp \
@@ -44,8 +45,9 @@ ARG TORCH_SPEC="torch==2.11.0"                        # DeepEP _C.so links this 
 ARG TORCH_INDEX="https://download.pytorch.org/whl/cu130"
 ARG NVIDIA_NCCL_CU13="2.30.4"                         # 2.28.x lacks the GIN/LSA symbols the plugin needs
 ARG NVSHMEM_CU13="3.6.5"
+ARG NINJA_VER="1.13.2"                                # pinned like every other pip dep here
 RUN pip3 install --no-cache-dir --index-url "${TORCH_INDEX}" "${TORCH_SPEC}" \
-    && pip3 install --no-cache-dir "nvidia-nccl-cu13==${NVIDIA_NCCL_CU13}" "nvidia-nvshmem-cu13==${NVSHMEM_CU13}" ninja
+    && pip3 install --no-cache-dir "nvidia-nccl-cu13==${NVIDIA_NCCL_CU13}" "nvidia-nvshmem-cu13==${NVSHMEM_CU13}" "ninja==${NINJA_VER}"
 # ninja is baked here EXPLICITLY (build_deepep.sh device-links the DeepEP extension, which
 # requires it): first pod boot must not depend on PyPI egress — private-subnet/air-gapped
 # clusters would otherwise fail inside a compile step instead of a clear network error.

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/Dockerfile
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # installer's NGC auto-detect and silently reroutes it down the libnccl-ofi-ngc path.
 # We build aws-ofi-nccl from source ourselves (Layer 4), so force the normal install —
 # same explicit choice as the sibling sglang/dsr1-deepep-efa and vllm/dsv3-uccl-nixl samples.
-ARG EFA_INSTALLER_VER=1.49.0                          # pin — no 'latest' (the stack under test)
+ARG EFA_INSTALLER_VER=1.50.0                          # pin, no 'latest'; matches micro-benchmarks/expert-parallelism/deepep-v2-benchmark/deepep.Dockerfile
 RUN apt-get update \
     && curl -fsSL https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VER}.tar.gz | tar -xzf - -C /tmp \
     && cd /tmp/aws-efa-installer && ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify --disable-ngc \
@@ -57,8 +57,8 @@ RUN NCCL_ROOT=$(python3 -c "import nvidia.nccl, pathlib; print(pathlib.Path(nvid
 # ---- Layer 3b: gdrcopy userspace (PUBLIC: github.com/NVIDIA/gdrcopy) ----
 # aws-ofi-nccl's GIN path REQUIRES gdrapi.h at configure time — without it the plugin
 # compiles with "GDRCopy support not available", nccl_ofi_gin_init fails at serve, and
-# DeepEP's ElasticBuffer asserts ginType==NCCL_GIN_TYPE_NONE. Userspace 2.5.2 on a
-# gdrdrv-2.4 host is exactly the pairing OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1 (#1351) fixes.
+# DeepEP's ElasticBuffer asserts ginType==NCCL_GIN_TYPE_NONE. Userspace 2.5.2 pairs with
+# the gdrdrv >= 2.5 kernel module the compute nodes must load (README Prerequisites).
 # gdrcopy v2.5.2 == commit c91ad9f: pin the commit, not the tag (a bare tag is a moving ref
 # upstream can re-point — every other dep here is SHA-pinned).
 ARG GDRCOPY_SHA=c91ad9f178e5fb729fc5b6dc62a77c3bb364d6c9
@@ -69,13 +69,10 @@ RUN git clone https://github.com/NVIDIA/gdrcopy.git /tmp/gdrcopy \
 
 # ---- Layer 4: aws-ofi-nccl GIN + DeepEP-V2 source (in-tree script, COPY'd not curled) ----
 COPY setup_deepep_v2_efa.sh /opt/setup_deepep_v2_efa.sh
-ARG AWS_OFI_NCCL_SHA=9c44d34476f90ddbf4a12d0ac4fc412d46bd8ab4
-ARG AWS_OFI_NCCL_PR=1351
-ARG AWS_OFI_NCCL_PR_SHA=c2e773dfb2c75b765b3415f8ffd1b47e7c239a7b  # IMMUTABLE PR#1351 head (FORCED_PCIE param; a bare refs/pull/N/head is a moving ref)
+ARG AWS_OFI_NCCL_REF=v1.21.1                              # released tag (the canonical deepep-v2-benchmark's aws-ofi-nccl version)
 ARG DEEPEP_SHA=97d8f9bcc1be31e9036db2ab591ef9b9f4e38619   # amazon-contributing/DeepEP@main, 2026-09-03 (the canonical V2/GIN source)
 RUN chmod +x /opt/setup_deepep_v2_efa.sh \
-    && AWS_OFI_NCCL_SHA=${AWS_OFI_NCCL_SHA} AWS_OFI_NCCL_PR=${AWS_OFI_NCCL_PR} AWS_OFI_NCCL_PR_SHA=${AWS_OFI_NCCL_PR_SHA} \
-       DEEPEP_SHA=${DEEPEP_SHA} \
+    && AWS_OFI_NCCL_REF=${AWS_OFI_NCCL_REF} DEEPEP_SHA=${DEEPEP_SHA} \
        /opt/setup_deepep_v2_efa.sh
 ENV LD_LIBRARY_PATH=/opt/aws-ofi-nccl/lib:${LD_LIBRARY_PATH}
 

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
@@ -1,0 +1,269 @@
+<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0 -->
+# NVIDIA Dynamo serving DeepEP-V2 MoE all-to-all over EFA
+
+Serve a Mixture-of-Experts model with **NVIDIA Dynamo** (`dynamo.frontend` OpenAI ingress +
+`dynamo.vllm` engine) using **DeepEP-V2** (`ElasticBuffer`) expert-parallel all-to-all, routed over
+**AWS EFA** via the NCCL-GIN **CPU-proxy** path (`NCCL_GIN_TYPE=2`). `dynamo.vllm` wraps the same vLLM
+engine as the sibling `../../vllm/deepep-v2-efa` sample (it forwards every unknown CLI flag straight
+into vLLM's `AsyncEngineArgs`), so **nothing about the DeepEP-V2 / EFA transport changes** — this
+sample adds only an OpenAI-compatible frontend and a DP/EP-aware worker wrapper on top of that proven
+substrate. It is the V2 / NCCL-GIN counterpart to the NVSHMEM-backed `../../sglang/dsr1-deepep-efa`
+sample: no NVSHMEM, no IBGDA — DeepEP-V2's `ElasticBuffer` drives the dispatch/combine collectives
+over `aws-ofi-nccl`'s GIN plugin on `efa-direct`.
+
+Validated on **2× and 4× p5en.48xlarge (H200)**, `Qwen/Qwen3-30B-A3B-FP8`: **measured at DP16/EP16**
+(the concurrency sweeps in `benchmarks/`); **DP32/EP32 functionally validated** (16/16 HTTP 200
+bring-up, no measured sweep — the shipped manifest is the 2-node/EP16 shape).
+
+## Relationship to the vLLM sample
+
+This sample is the vLLM-DeepEP-V2 substrate (`../../vllm/deepep-v2-efa`) **plus a Dynamo serving
+front**. Everything below the serving layer is shared and byte-identical:
+
+| Shared with `../../vllm/deepep-v2-efa` (identical) | Dynamo-specific (the only delta) |
+|---|---|
+| `Dockerfile` Layers 1–5b (NGC base, EFA, torch cu13, gdrcopy, aws-ofi-nccl GIN + #1351, DeepEP-V2, pinned vLLM wheel) | `Dockerfile` Layer 5c: `pip install --no-deps ai-dynamo{,-runtime}==1.3.1` |
+| `setup_deepep_v2_efa.sh`, `recipe/build_deepep.sh`, `recipe/run-kernel-test.sh`, `recipe/verify-image.sh`, `recipe/benchmark*.{sh,py}` | `recipe/serve.sh`: launches `dynamo.frontend` + `dynamo.vllm` (vs `vllm serve`) |
+| The proxy-Gin/EFA env contract, the DP-coordinator flags, the model, the EP-divisibility preflight | `kubernetes/dynamo-deepep-v2-2node.yaml`: readiness probe + names |
+
+`dynamo.vllm` uses `parse_known_args`, so the DeepEP-V2 backend selection (`--all2all-backend
+deepep_v2`), the DP-coordinator wiring (`--data-parallel-*`), and the eager/revision flags all pass
+through into vLLM unchanged — the `COMMON` flag block in `recipe/serve.sh` is identical to the vLLM
+sample's. If you only need a raw OpenAI endpoint with no Dynamo router/planner, the vLLM sample is the
+simpler choice; use this one when you want Dynamo's frontend (and a path to its KV-router / planner)
+in front of the same DeepEP-V2/EFA engine.
+
+## How DeepEP-V2 gets onto EFA
+
+DeepEP's default transport is NVSHMEM/IBGDA, which EFA does not provide. The V2 (`ElasticBuffer`) path
+instead runs its dispatch/combine over `aws-ofi-nccl`'s **GIN CPU-proxy** (`NCCL_GIN_TYPE=2`,
+`OFI_NCCL_GIN_GDAKI=0`) on the `efa-direct` fabric. Three things make this work, and two of them are
+non-obvious integration fixes, not config:
+
+### Integration fixes baked into this sample
+
+1. **`EP_REUSE_NCCL_COMM=0` (required, or serve init segfaults).** Upstream DeepEP flipped this default
+   to `1` (reuse torch's NCCL comm). Under vLLM, torch creates NCCL comms lazily and has run no
+   collective on the EP group before `ElasticBuffer` construction, so `_comm_ptr()` returns `0` →
+   `ncclTeamWorld(nullptr)` → deterministic segfault on all ranks. Setting `0` restores DeepEP's
+   create-own-comm path. (Env, set in `recipe/serve.sh` and `kubernetes/`.)
+2. **The gdrcopy forced-PCIe capability** for the GIN plugin on gdrdrv-2.4 hosts, via
+   `OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1` — the parameterized fix from
+   [aws/aws-ofi-nccl#1351](https://github.com/aws/aws-ofi-nccl/pull/1351), cherry-picked at a pinned SHA
+   in `setup_deepep_v2_efa.sh` (no local patch file).
+3. **DeepEP-V2 source** = `b306af06` + [PR#612](https://github.com/deepseek-ai/DeepEP/pull/612) (EFA
+   auto-QP cap), pinned to the PR's **immutable head SHA** (a bare `refs/pull/N/head` is a moving ref).
+
+### eager vs non-eager (see `benchmarks/`)
+
+| Mode | Status | How |
+|---|---|---|
+| `--enforce-eager` | **Serves, zero extra patches — the shipped, measured, supported path** | the default this sample ships (`SERVE_ENFORCE_EAGER=1`) |
+| default compilation (CUDA graphs) | **NOT supported at the shipped pin** | needs the empty-`ExpertTokensMetadata` guard ([vLLM #52632](https://github.com/vllm-project/vllm/pull/52632), merged 2026-08-20), which is **only on the vLLM 0.26 line** — and 0.26 separately regresses the `deepep_v2` combine on this DeepEP/EFA substrate (see below), so we cannot pin forward to reach it. The historical non-eager `benchmarks/` tables were taken on this pin with #52632 applied as an **unmerged cherry-pick**. |
+
+The shipped vLLM pin is `e2f993dc4` — the merge commit of [PR#41183](https://github.com/vllm-project/vllm/pull/41183),
+the first (and, on this EFA/DeepEP substrate, only measured-working) `deepep_v2` backend, `0.22.1rc1.dev283`.
+At this pin, default (non-eager) compilation crashes deterministically ~48 s into startup in `profile_run`
+(`deepep_v2.py` combine); `--enforce-eager` avoids it and is the path this sample ships and supports.
+
+> **Why the pin is not bumped forward to pick up #52632:** vLLM 0.26 (the line that carries #52632)
+> regresses the `deepep_v2` combine on this exact DeepEP `_C.so` / EFA substrate — a DP16/EP16 serve
+> faults `CUDA_ERROR_LAUNCH_FAILED (719)` in `profile_run` → `determine_available_memory` during
+> KV-cache sizing (measured 2026-09-04, eager **and** non-eager), while the standalone cross-node
+> kernel-test still passes on the same image. So the fault is 0.26's DeepEP-V2 driver, not the kernels
+> or EFA. `e2f993dc4` (0.22) is the newest vLLM proven to serve `deepep_v2` DP16/EP16 over EFA; the pin
+> stays there until a newer vLLM line is re-measured green on this substrate.
+
+<!-- MD028: separate the two blockquotes so the blank line is not read as inside one quote -->
+
+> **Shared-experts caveat when bumping the pin:** at `e2f993dc4` there is a second, independent
+> non-eager crash cause that bites models with shared experts (DeepSeek-V3/R1, DeepSeek-V2-Lite —
+> models `serve.sh` explicitly supports): the `-1` sentinel expert IDs that vLLM
+> [#46432](https://github.com/vllm-project/vllm/pull/46432) legitimately produces reach
+> `moe_align_sum_kernels.cu`, which guards `expert_id >= num_experts` but not `expert_id < 0`
+> (out-of-bounds atomic write). Upstream fixed it in
+> [#47785](https://github.com/vllm-project/vllm/pull/47785) (merged 2026-07-10). Qwen3-30B-A3B has
+> no shared experts, which is why the sweeps here were green without it. Any pin past
+> [#52632](https://github.com/vllm-project/vllm/pull/52632)'s merge also includes #47785 (it merged
+> earlier), so the "bump the pin past #52632" guidance below picks up both fixes.
+
+## Prerequisites
+
+- An EKS cluster of p5en.48xlarge (H200) with EFA + the EFA K8s device plugin (the shipped launcher);
+  the container also runs under raw `docker run` on any 2 EFA hosts if you wire the rendezvous by hand.
+- An ECR repo you own (set in `setup/env_vars`); this sample never hardcodes a registry.
+- Hugging Face access for the model (`Qwen/Qwen3-30B-A3B-FP8` is public, no token required).
+
+## Build
+
+```bash
+cp setup/env_vars.example setup/env_vars && $EDITOR setup/env_vars   # set REGISTRY, IMAGE_TAG
+bash setup/build-push.sh
+```
+
+The image is NGC-from-scratch (`FROM nvcr.io/nvidia/cuda:...`). `setup_deepep_v2_efa.sh` builds
+aws-ofi-nccl (GIN + the #1351 param) and stages DeepEP-V2 source; the `_C.so` is compiled in-pod on
+first boot (needs a live CUDA context) by `recipe/`-invoked `build_deepep.sh`. Dynamo is added in
+Layer 5c as `pip install --no-deps ai-dynamo{,-runtime}==1.3.1` — `--no-deps` is load-bearing: without
+it, pip would pull `ai-dynamo`'s `vllm[...]==0.23.0` dependency and overwrite the pinned `VLLM_SHA`
+build (and drag `nvidia-nccl-cu13` back to torch's 2.28.x, undoing the ABI re-pin). The in-tree
+`Dockerfile` is the canonical, reviewable build. The shipped vLLM pin (`e2f993dc4`) is the **exact**
+substrate the `benchmarks/` tables were measured on, so a rebuild reproduces them — see
+`benchmarks/README.md`.
+
+The one image name used everywhere is `${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}` from
+`setup/env_vars` (`build-push.sh` builds and pushes exactly that; point the manifest's `image:` at
+the same).
+
+## Smoke-test the EFA transport before loading the model
+
+**1. Static image check (single node, no rendezvous):**
+
+```bash
+source setup/env_vars && bash recipe/verify-image.sh "${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
+```
+
+Asserts (fail-loud) the efa provider resolves (`fi_info` — the live `efa-direct` fabric check runs
+when `/dev/infiniband` is present on the host), a single pinned libnccl wins **with the GIN/LSA
+symbols present**, the GIN plugin exports `ncclGinPlugin`, and the DeepEP-V2 source (ElasticBuffer +
+the kernel-smoke test) is staged at `/opt/DeepEP`. The `import deep_ep` assertion happens in-pod
+after `build_deepep.sh`, not here — the `_C.so` is deliberately not baked into the image.
+
+**2. Cross-node kernel smoke (prove bytes move over EFA before the model load):**
+
+```bash
+# in the pods/containers, one per node — runs DeepEP-V2's own elastic EP test
+bash /opt/run-kernel-test.sh leader <leader-ip>            # node 0
+bash /opt/run-kernel-test.sh worker <leader-ip> 1          # node 1
+```
+
+Runs `DeepEP/tests/elastic/test_ep.py` across the nodes with the exact proxy-Gin/EFA env the serve
+uses, and only prints `KERNEL-TEST PASS` when the test passes **and** the `NCCL_DEBUG=INFO` log shows
+the `efa-direct` banner (so a green result cannot be a silent TCP/SHM fallback). This is the one step
+that cannot hang for hours — run it before committing a node to the multi-hundred-GB weight load.
+
+For a standalone DeepEP-V2 dispatch/combine benchmark of the fabric itself (numbers, not just
+pass/fail — and without any vLLM in the loop), use the repo's runnable V2 micro-benchmark:
+[`micro-benchmarks/expert-parallelism/deepep-v2-benchmark/`](../../../../micro-benchmarks/expert-parallelism/deepep-v2-benchmark/)
+(own image + Slurm launchers; same NCCL-GIN/EFA transport this sample serves over).
+
+## Serve
+
+Dynamo splits the serving front from the engine, so the launcher is **one invocation per node** with a
+role (see the header of `recipe/serve.sh` for the topology):
+
+```bash
+# eager (default). SERVE_DP = total data-parallel = EP size; SERVE_DP_LOCAL = GPUs/node.
+# node 0 (leader): dynamo.frontend on :8000 (OpenAI HTTP) + dynamo.vllm (non-headless) DP ranks 0..7
+SERVE_DP=16 bash recipe/serve.sh leader <leader-ip>
+# node 1 (worker): dynamo.vllm --headless, DP start-rank 8 (= ORDINAL × SERVE_DP_LOCAL)
+SERVE_DP=16 bash recipe/serve.sh worker <leader-ip> 8
+```
+
+Only the leader runs the frontend, so the OpenAI API is on **the leader pod's** `:8000`
+(`dynamo-deepep-v2-0`), not on the workers. Discovery is the **file backend**
+(`--discovery-backend file`), which is node-0-local (frontend ↔ leader engine only); the worker is
+`--headless` and joins the DP group purely through vLLM's native data-parallel RPC to the leader over
+EFA, so there is **no etcd/NATS and no shared discovery volume** to provision.
+
+Serve **eager** — it is the shipped default (`SERVE_ENFORCE_EAGER=1`) and the only supported mode at
+the shipped pin. Default (CUDA-graph) compilation crashes at this pin (`e2f993dc4`) in `profile_run`;
+the guard that fixes it ([vLLM #52632](https://github.com/vllm-project/vllm/pull/52632)) is only on the
+vLLM 0.26 line, which separately regresses the `deepep_v2` combine here (see "eager vs non-eager"), so
+`SERVE_ENFORCE_EAGER=0` is not a supported path in this sample — the knob still exists but warns and
+will crash. Kubernetes: `kubectl apply -f kubernetes/` (2-node StatefulSet + headless service; the
+proxy-Gin env contract + EFA device requests are set there).
+
+### Readiness on Dynamo — why `/health` alone lies
+
+The Kubernetes leader probe requires `/health` to be 200 **AND** carry a non-empty `endpoints` array —
+not a bare `curl -sf /health`. This is deliberate and Dynamo-specific:
+
+- `dynamo.frontend`'s `/health` returns **200 as soon as the HTTP server binds** (~6 s). Its
+  `ServiceObserver` defaults to `Ready` and only leaves `Ready` on shutdown — **nothing flips it to
+  Ready on engine registration**. So a bare `/health` check reports "healthy" with an empty
+  `instances: []`, *hours* before the multi-hundred-GB model finishes loading — which would defeat the
+  `startupProbe`'s 60-minute compile+load budget.
+- The engine registers with the frontend **only after the weight load** (`dynamo.vllm`'s
+  `register_model()` runs after `AsyncLLM.from_vllm_config`). Once it does, `/health`'s response body
+  populates its `endpoints`/`instances` arrays.
+- Therefore the honest readiness signal is **`/health` is 200 *and* has ≥1 endpoint**. The probe uses
+  `curl -sf .../health | grep -qF '"endpoints":["'`, which matches only a populated array (an empty
+  `"endpoints":[]` fails the match).
+
+Workers are `--headless` (no HTTP server, and they never register a discovery endpoint), so their
+probe is **process-liveness only** (`pgrep -f dynamo.vllm`). A worker's startup passes on its first
+tick and a wedged-but-alive worker stays Ready — a known limitation, not a readiness check. A worker's
+true progress is observed through the leader coming Ready: the DP rendezvous cannot complete (and the
+leader cannot register its engine) until every worker has joined. This pairs with
+`publishNotReadyAddresses: true` on the headless Service — workers must resolve the leader's DNS
+A-record *before* the leader is Ready, or the rendezvous deadlocks.
+
+## Benchmark
+
+```bash
+# from inside the leader pod (both scripts are baked into the image at /opt):
+kubectl -n dynamo-deepep exec dynamo-deepep-v2-0 -- env OUT_ROOT=/work/benchmarks bash /opt/benchmark.sh 127.0.0.1
+
+# or from outside the cluster, via a port-forward to the leader pod:
+kubectl -n dynamo-deepep port-forward pod/dynamo-deepep-v2-0 8000:8000 &
+bash recipe/benchmark.sh 127.0.0.1
+```
+
+Concurrency sweep 1/8/16/32/64 (5× requests per level), writes `benchmarks/raw/`. Exits non-zero
+unless **every** request at **every** level succeeded. See `benchmarks/README.md` for the measured
+eager and non-eager tables + environment provenance.
+
+## Known limitations
+
+- Measured on **H200 (p5en, `sm_90`) only**; no Blackwell serving run is in this sample. The manifest's
+  `DEEPEP_ARCH_LIST=10.0` (p6-b200) / `10.3` (p6-b300) knobs are **documented but not verified** at the
+  shipped DeepEP pin: on 2× p6-b300 the DeepEP runtime JIT produced no loadable kernel (a Blackwell PTX
+  codegen failure at CUDA 13.0 on the `deepseek-ai/DeepEP@b306af06` lineage). The
+  [`amazon-contributing/DeepEP`](https://github.com/amazon-contributing/DeepEP) fork the canonical
+  benchmark pins carries the `st.bulk` 64-bit-operand fix
+  ([#3](https://github.com/amazon-contributing/DeepEP/pull/3)) that makes CUDA 13.0 work on Blackwell;
+  moving this sample's `DEEPEP_SHA`/`DEEPEP_REPO` to that fork is the intended path to enabling those
+  rows, and should be re-verified on Blackwell before the knobs are advertised as working.
+- The `benchmarks/` numbers are an **at-scale throughput + relative-latency** datapoint (fixed 128-token
+  greedy decode, single sweep per mode), **not** a tuned per-token-latency (TTFT) baseline.
+- **Only eager (`--enforce-eager`) serving is supported at the shipped pin.** Default-compilation
+  (non-eager) serving needs the empty-`ExpertTokensMetadata` guard
+  ([vLLM #52632](https://github.com/vllm-project/vllm/pull/52632), merged 2026-08-20), which is only on
+  the vLLM 0.26 line — and 0.26 separately regresses the `deepep_v2` combine on this DeepEP/EFA substrate
+  (`CUDA_ERROR_LAUNCH_FAILED (719)` in `profile_run`, measured 2026-09-04), so the pin cannot be moved
+  forward to reach the guard. This sample therefore carries **no build-time patches** and ships eager.
+  The non-eager numbers in `benchmarks/` were measured on this same pin (`e2f993dc4`) with #52632 applied
+  as an unmerged cherry-pick; they are **historical** — a stock rebuild of this sample serves eager only.
+- Only a **Kubernetes** launcher is shipped and exercised (`kubernetes/`). No Slurm/Pyxis `.sbatch` is
+  provided because none was run; the raw two-node `recipe/serve.sh` path is the manual fallback.
+- The Dynamo front is `dynamo.frontend` + `dynamo.vllm` with the **file** discovery backend and vLLM's
+  native DP coordinator for cross-node fan-out. The Dynamo **KV router / planner / disaggregated
+  prefill-decode** paths are **not** exercised here — this sample proves DeepEP-V2 MoE all-to-all over
+  EFA under a Dynamo front, not those higher-level Dynamo features.
+- `setup_deepep_v2_efa.sh` is a **documented variant** of the repo's canonical V2/GIN provisioner,
+  [`micro-benchmarks/expert-parallelism/deepep-v2-benchmark/setup_deepep_gin.sh`](../../../../micro-benchmarks/expert-parallelism/deepep-v2-benchmark/setup_deepep_gin.sh)
+  (which appeared 2026-08-24). When the canonical moves, that is the file to track. Three deliberate
+  divergences justify a separate script here; the next reader should know they are choices, not drift:
+  1. **The unmerged aws-ofi-nccl #1351 parameter.** This sample cherry-picks
+     [aws/aws-ofi-nccl#1351](https://github.com/aws/aws-ofi-nccl/pull/1351)
+     (`OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY`) at a pinned head SHA; the canonical builds a stock GIN NCCL
+     and does not carry it. Until #1351 merges, this recipe cannot be a thin call into the canonical.
+  2. **CPU-proxy (`NCCL_GIN_TYPE=2`), not EFA-GDA.** This is the GDAKI-off, CPU-proxy transport that is
+     viable on EFA today; the canonical benchmark's defaults and NCCL build target a different point in
+     that design space.
+  3. **Coupling to the vLLM wheel's torch/NCCL ABI.** The DeepEP `_C.so` here is built in-pod against
+     the exact `torch 2.11+cu130` / `nvidia-nccl-cu13 2.30.4` the pinned vLLM wheel drags in (Dockerfile
+     Layer 5b re-pins it), so the toolchain is wheel-driven rather than a standalone NCCL build tree.
+
+  The **DeepEP source** is the one divergence with a concrete cost, called out at
+  `setup_deepep_v2_efa.sh` (see the header note there): the canonical pins the
+  [`amazon-contributing/DeepEP`](https://github.com/amazon-contributing/DeepEP) fork, which carries the
+  Blackwell `st.bulk` 64-bit-operand fix ([amazon-contributing/DeepEP#3](https://github.com/amazon-contributing/DeepEP/pull/3),
+  merged 2026-08-24); this sample pins `deepseek-ai/DeepEP@b306af06`+PR#612, which does not. The
+  `benchmarks/` numbers were measured on H200 (`sm_90`), where this does not bite — see the Blackwell
+  caveat under **Known limitations** before using the `DEEPEP_ARCH_LIST=10.x` knob.
+- `setup_deepep_v2_efa.sh` is deliberately **outside** `.github/workflows/deepep-vendor-sync.yml`. That
+  CI gates only the NVSHMEM `setup_deepep_efa.sh` vendored copy (canonical at
+  `micro-benchmarks/expert-parallelism/deepep-benchmark/`) — a different script — so this V2/GIN variant
+  is correctly not in that workflow. Do not add it to that workflow.

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
@@ -136,9 +136,11 @@ bash setup/build-push.sh
 The image is NGC-from-scratch (`FROM nvcr.io/nvidia/cuda:...`). `setup_deepep_v2_efa.sh` builds
 aws-ofi-nccl (GIN, released `v1.21.1`) and stages the DeepEP-V2 source; the `_C.so` is compiled in-pod on
 first boot (needs a live CUDA context) by `recipe/`-invoked `build_deepep.sh`. Dynamo is added in
-Layer 5c as `pip install --no-deps ai-dynamo{,-runtime}==1.3.1` — `--no-deps` is load-bearing: without
-it, pip would pull `ai-dynamo`'s `vllm[...]==0.23.0` dependency and overwrite the pinned `VLLM_SHA`
-build (and drag `nvidia-nccl-cu13` back to torch's 2.28.x, undoing the ABI re-pin). The in-tree
+Layer 5c as `pip install --no-deps ai-dynamo{,-runtime}==1.3.1` — `--no-deps` is load-bearing: it
+keeps pip from re-resolving `ai-dynamo`'s nine unconditional dependencies (`transformers`,
+`prometheus-client`, `msgspec`, `pyzmq`, …) over the versions the pinned vLLM wheel installed. (Its
+`vllm[...]==0.23.0` entry is an opt-in extra a bare install never resolves — see the Dockerfile
+Layer-5c comment for the full mechanism.) The in-tree
 `Dockerfile` is the canonical, reviewable build. The shipped vLLM pin (`e2f993dc4`) is the **exact**
 substrate the `benchmarks/` tables were measured on, so a rebuild reproduces them — see
 `benchmarks/README.md`.

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
@@ -12,7 +12,8 @@ sample: no NVSHMEM, no IBGDA — DeepEP-V2's `ElasticBuffer` drives the dispatch
 over `aws-ofi-nccl`'s GIN plugin on `efa-direct`.
 
 Validated on **2× and 4× p5en.48xlarge (H200)**, `Qwen/Qwen3-30B-A3B-FP8`: **measured at DP16/EP16**
-(the concurrency sweeps in `benchmarks/`); **DP32/EP32 functionally validated** (16/16 HTTP 200
+(the concurrency sweeps in `benchmarks/` — measured on the sibling vLLM sample's image, not this
+Dynamo image; see `benchmarks/README.md`); **DP32/EP32 functionally validated** (16/16 HTTP 200
 bring-up, no measured sweep — the shipped manifest is the 2-node/EP16 shape).
 
 ## Relationship to the vLLM sample
@@ -141,9 +142,11 @@ keeps pip from re-resolving `ai-dynamo`'s nine unconditional dependencies (`tran
 `prometheus-client`, `msgspec`, `pyzmq`, …) over the versions the pinned vLLM wheel installed. (Its
 `vllm[...]==0.23.0` entry is an opt-in extra a bare install never resolves — see the Dockerfile
 Layer-5c comment for the full mechanism.) The in-tree
-`Dockerfile` is the canonical, reviewable build. The shipped vLLM pin (`e2f993dc4`) is the **exact**
-substrate the `benchmarks/` tables were measured on, so a rebuild reproduces them — see
-`benchmarks/README.md`.
+`Dockerfile` is the canonical, reviewable build. The shipped vLLM pin (`e2f993dc4`) matches the
+substrate the `benchmarks/` tables were measured on — but those tables were measured on the
+**sibling vLLM sample's image** with an earlier probe revision, **not on this Dynamo image**, so a
+rebuild of this sample does **not** reproduce them — see `benchmarks/README.md` for the full
+provenance.
 
 The one image name used everywhere is `${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}` from
 `setup/env_vars` (`build-push.sh` builds and pushes exactly that; point the manifest's `image:` at
@@ -263,8 +266,17 @@ bash recipe/benchmark.sh 127.0.0.1
 ```
 
 Concurrency sweep 1/8/16/32/64 (5× requests per level), writes `benchmarks/raw/`. Exits non-zero
-unless **every** request at **every** level succeeded. See `benchmarks/README.md` for the measured
-eager and non-eager tables + environment provenance.
+unless **every** request at **every** level succeeded.
+
+**Persist the raws off-pod before deleting the pods** — `/work` is an `emptyDir` and dies with the
+pod (the original sweeps' raws were lost exactly this way):
+
+```bash
+kubectl -n dynamo-deepep cp dynamo-deepep-v2-0:/work/benchmarks "./benchmarks-raw-$(date -u +%Y%m%dT%H%M%SZ)"
+```
+
+See `benchmarks/README.md` for the measured eager and non-eager tables + environment provenance
+(measured on the sibling vLLM sample's image — not re-measured on this Dynamo image).
 
 ## Known limitations
 

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
@@ -203,9 +203,12 @@ not a bare `curl -sf /health`. This is deliberate and Dynamo-specific:
 - The engine registers with the frontend **only after the weight load** (`dynamo.vllm`'s
   `register_model()` runs after `AsyncLLM.from_vllm_config`). Once it does, `/health`'s response body
   populates its `endpoints`/`instances` arrays.
-- Therefore the honest readiness signal is **`/health` is 200 *and* has ≥1 endpoint**. The probe uses
-  `curl -sf .../health | grep -qF '"endpoints":["'`, which matches only a populated array (an empty
-  `"endpoints":[]` fails the match).
+- Therefore the honest readiness signal is **`/health` is 200 *and* has ≥1 endpoint**. The probe
+  checks that structurally — `curl -sf .../health | python3 -c 'import json,sys; sys.exit(0 if
+  json.load(sys.stdin).get("endpoints") else 1)'` — so it does not depend on how the frontend
+  happens to serialize the body: a populated `endpoints` array passes, an empty one (or non-JSON)
+  fails, and a formatting change across a Dynamo bump cannot turn a succeeding load into a probe
+  kill.
 
 Workers are `--headless` (no HTTP server, and they never register a discovery endpoint), so their
 probe is **process-liveness only** (`pgrep -f dynamo.vllm`). A worker's startup passes on its first
@@ -214,6 +217,21 @@ true progress is observed through the leader coming Ready: the DP rendezvous can
 leader cannot register its engine) until every worker has joined. This pairs with
 `publishNotReadyAddresses: true` on the headless Service — workers must resolve the leader's DNS
 A-record *before* the leader is Ready, or the rendezvous deadlocks.
+
+### Update / recovery — all pods together, never one at a time
+
+The DP rendezvous is **one-shot**: a restarted pod cannot rejoin a group whose other members kept
+running. The StatefulSet therefore ships `updateStrategy: OnDelete`, and the single update **and**
+recovery procedure is to delete all pods together so the group re-forms from scratch:
+
+```bash
+kubectl -n dynamo-deepep delete pod -l app=dynamo-deepep-v2   # roll a new image tag / recover a wedged group
+```
+
+The default rolling update would replace pods one at a time, each replacement joining a collective
+that no longer exists while the survivor keeps reporting Ready. The leader also carries a
+`livenessProbe` (same exec as readiness, gated by the `startupProbe`) so frontend death or a wedged
+leader turns into a visible restart — after which the all-pods delete above is the recovery.
 
 ## Benchmark
 

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
@@ -17,8 +17,11 @@ bring-up, no measured sweep — the shipped manifest is the 2-node/EP16 shape).
 
 ## Relationship to the vLLM sample
 
-This sample is the vLLM-DeepEP-V2 substrate (`../../vllm/deepep-v2-efa`) **plus a Dynamo serving
-front**. Everything below the serving layer is shared and byte-identical:
+This sample is the vLLM-DeepEP-V2 substrate (`../../vllm/deepep-v2-efa`,
+[PR #1230](https://github.com/awslabs/awsome-distributed-ai/pull/1230)) **plus a Dynamo serving
+front**. Everything below the serving layer is shared by design — same layers, same scripts, same
+env contract. (This sample's substrate pins may lead the sibling's while the two reviews converge;
+the recipes re-align as the sibling's review lands.)
 
 | Shared with `../../vllm/deepep-v2-efa` (identical) | Dynamo-specific (the only delta) |
 |---|---|
@@ -51,8 +54,13 @@ non-obvious integration fixes, not config:
    `OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1` — the parameterized fix from
    [aws/aws-ofi-nccl#1351](https://github.com/aws/aws-ofi-nccl/pull/1351), cherry-picked at a pinned SHA
    in `setup_deepep_v2_efa.sh` (no local patch file).
-3. **DeepEP-V2 source** = `b306af06` + [PR#612](https://github.com/deepseek-ai/DeepEP/pull/612) (EFA
-   auto-QP cap), pinned to the PR's **immutable head SHA** (a bare `refs/pull/N/head` is a moving ref).
+3. **DeepEP-V2 source** = the
+   [`amazon-contributing/DeepEP`](https://github.com/amazon-contributing/DeepEP) fork at a pinned SHA
+   (`97d8f9bc`) — the same source the repo's canonical V2/GIN provisioner pins ("the benchmark
+   supports no other source"). The fork carries the in-tree successors of deepseek
+   [PR#612](https://github.com/deepseek-ai/DeepEP/pull/612)'s EFA work: the QP count clamps from `_C`
+   runtime constants and the RDMA link rate is probed from sysfs, so no `EP_EFA_MAX_QPS` /
+   `EP_EFA_RDMA_GBS` env exists (or is set) in this sample.
 
 ### eager vs non-eager (see `benchmarks/`)
 
@@ -217,14 +225,13 @@ eager and non-eager tables + environment provenance.
 ## Known limitations
 
 - Measured on **H200 (p5en, `sm_90`) only**; no Blackwell serving run is in this sample. The manifest's
-  `DEEPEP_ARCH_LIST=10.0` (p6-b200) / `10.3` (p6-b300) knobs are **documented but not verified** at the
-  shipped DeepEP pin: on 2× p6-b300 the DeepEP runtime JIT produced no loadable kernel (a Blackwell PTX
-  codegen failure at CUDA 13.0 on the `deepseek-ai/DeepEP@b306af06` lineage). The
-  [`amazon-contributing/DeepEP`](https://github.com/amazon-contributing/DeepEP) fork the canonical
-  benchmark pins carries the `st.bulk` 64-bit-operand fix
-  ([#3](https://github.com/amazon-contributing/DeepEP/pull/3)) that makes CUDA 13.0 work on Blackwell;
-  moving this sample's `DEEPEP_SHA`/`DEEPEP_REPO` to that fork is the intended path to enabling those
-  rows, and should be re-verified on Blackwell before the knobs are advertised as working.
+  `DEEPEP_ARCH_LIST=10.0` (p6-b200) / `10.3` (p6-b300) knobs are **documented but not verified**: an
+  earlier bring-up on 2× p6-b300 hit a Blackwell PTX codegen failure at CUDA 13.0 on the
+  `deepseek-ai/DeepEP@b306af06` lineage this sample previously pinned. The shipped pin is now the
+  [`amazon-contributing/DeepEP`](https://github.com/amazon-contributing/DeepEP) fork, which carries the
+  `st.bulk` 64-bit-operand fix ([#3](https://github.com/amazon-contributing/DeepEP/pull/3)) that removes
+  that specific codegen failure — but no Blackwell run exists at the shipped pin, so re-verify on p6
+  before advertising those rows as working.
 - The `benchmarks/` numbers are an **at-scale throughput + relative-latency** datapoint (fixed 128-token
   greedy decode, single sweep per mode), **not** a tuned per-token-latency (TTFT) baseline.
 - **Only eager (`--enforce-eager`) serving is supported at the shipped pin.** Default-compilation
@@ -256,13 +263,11 @@ eager and non-eager tables + environment provenance.
      the exact `torch 2.11+cu130` / `nvidia-nccl-cu13 2.30.4` the pinned vLLM wheel drags in (Dockerfile
      Layer 5b re-pins it), so the toolchain is wheel-driven rather than a standalone NCCL build tree.
 
-  The **DeepEP source** is the one divergence with a concrete cost, called out at
-  `setup_deepep_v2_efa.sh` (see the header note there): the canonical pins the
-  [`amazon-contributing/DeepEP`](https://github.com/amazon-contributing/DeepEP) fork, which carries the
-  Blackwell `st.bulk` 64-bit-operand fix ([amazon-contributing/DeepEP#3](https://github.com/amazon-contributing/DeepEP/pull/3),
-  merged 2026-08-24); this sample pins `deepseek-ai/DeepEP@b306af06`+PR#612, which does not. The
-  `benchmarks/` numbers were measured on H200 (`sm_90`), where this does not bite — see the Blackwell
-  caveat under **Known limitations** before using the `DEEPEP_ARCH_LIST=10.x` knob.
+  The **DeepEP source** matches the canonical: both pin the
+  [`amazon-contributing/DeepEP`](https://github.com/amazon-contributing/DeepEP) fork — this sample at
+  the immutable SHA `97d8f9bc` rather than the canonical's floating `main`, so the build is
+  reproducible. See the Blackwell caveat under **Known limitations** before using the
+  `DEEPEP_ARCH_LIST=10.x` knob.
 - `setup_deepep_v2_efa.sh` is deliberately **outside** `.github/workflows/deepep-vendor-sync.yml`. That
   CI gates only the NVSHMEM `setup_deepep_efa.sh` vendored copy (canonical at
   `micro-benchmarks/expert-parallelism/deepep-benchmark/`) — a different script — so this V2/GIN variant

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
@@ -4,8 +4,10 @@
 Serve a Mixture-of-Experts model with **NVIDIA Dynamo** (`dynamo.frontend` OpenAI ingress +
 `dynamo.vllm` engine) using **DeepEP-V2** (`ElasticBuffer`) expert-parallel all-to-all, routed over
 **AWS EFA** via the NCCL-GIN **CPU-proxy** path (`NCCL_GIN_TYPE=2`). `dynamo.vllm` wraps the same vLLM
-engine as the sibling `../../vllm/deepep-v2-efa` sample (it forwards every unknown CLI flag straight
-into vLLM's `AsyncEngineArgs`), so **nothing about the DeepEP-V2 / EFA transport changes** — this
+engine as the sibling **vLLM DeepEP-V2 sample**
+([PR #1230](https://github.com/awslabs/awsome-distributed-ai/pull/1230) — the `../../vllm/deepep-v2-efa`
+relative links throughout this sample resolve once it merges) (it forwards every unknown CLI flag
+straight into vLLM's `AsyncEngineArgs`), so **nothing about the DeepEP-V2 / EFA transport changes** — this
 sample adds only an OpenAI-compatible frontend and a DP/EP-aware worker wrapper on top of that proven
 substrate. It is the V2 / NCCL-GIN counterpart to the NVSHMEM-backed `../../sglang/dsr1-deepep-efa`
 sample: no NVSHMEM, no IBGDA — DeepEP-V2's `ElasticBuffer` drives the dispatch/combine collectives
@@ -22,7 +24,9 @@ This sample is the vLLM-DeepEP-V2 substrate (`../../vllm/deepep-v2-efa`,
 [PR #1230](https://github.com/awslabs/awsome-distributed-ai/pull/1230)) **plus a Dynamo serving
 front**. Everything below the serving layer is shared by design — same layers, same scripts, same
 env contract. (This sample's substrate pins may lead the sibling's while the two reviews converge;
-the recipes re-align as the sibling's review lands.)
+the recipes re-align as the sibling's review lands.) **Merge order: #1230 lands first** — this
+sample's relative sibling links and its byte-identity claims point at that folder, so until #1230
+merges they have nothing on `main` to resolve against.
 
 | Shared with `../../vllm/deepep-v2-efa` (identical) | Dynamo-specific (the only delta) |
 |---|---|

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
@@ -107,6 +107,22 @@ At this pin, default (non-eager) compilation crashes deterministically ~48 s int
   was never loaded — and the shipped plugin (released `v1.21.1`) carries no gdrdrv-2.4 workaround. The
   AWS GPU AMIs ship it; if absent, `sudo modprobe gdrdrv` (gdrcopy ≥ 2.5, matching the image's
   `c91ad9f`/v2.5.2 userspace build).
+- **2Mi hugepages pre-allocated on the compute nodes.** The manifest requests `hugepages-2Mi: 5120Mi`
+  per pod (= 2560 × 2Mi pages); the consumer is libfabric's EFA provider bounce-buffer pools.
+  Kubernetes only *accounts* hugepages — allocation is a node-bootstrap step (kernel cmdline
+  `hugepages=2560`, or `sysctl vm.nr_hugepages=2560` via a privileged DaemonSet, before the kubelet
+  starts). Without it the pods sit **Pending** with an unsatisfiable `hugepages-2Mi` request. The
+  nodes the measured runs used had them pre-allocated.
+- **Room for the weights where `emptyDir` actually lands.** The manifest's `work` volume
+  (`emptyDir: { sizeLimit: 900Gi }`) is backed by the filesystem holding `/var/lib/kubelet` — on a
+  stock EKS AMI that is the **EBS root volume**, not the p5en instance-store NVMe. A multi-hundred-GB
+  model download there fills the root disk and triggers a **node-wide `DiskPressure` eviction**, not
+  a pod-level failure. Size the root volume for your model, or remap `/var/lib/kubelet` (or the
+  volume) onto the instance store in the node bootstrap.
+- **`cpuManagerPolicy: static` on the kubelet** if you want what the manifest's Guaranteed QoS
+  (requests == limits) is there for: exclusive core pinning for the NCCL-GIN **CPU-proxy** threads,
+  which sit on the network data path. Without the static policy, Guaranteed QoS does **not** exempt
+  the pod from CFS throttling at its `cpu` limit (see the note in the manifest).
 - An ECR repo you own (set in `setup/env_vars`); this sample never hardcodes a registry.
 - Hugging Face access for the model (`Qwen/Qwen3-30B-A3B-FP8` is public, no token required).
 

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/README.md
@@ -25,7 +25,7 @@ the recipes re-align as the sibling's review lands.)
 
 | Shared with `../../vllm/deepep-v2-efa` (identical) | Dynamo-specific (the only delta) |
 |---|---|
-| `Dockerfile` Layers 1–5b (NGC base, EFA, torch cu13, gdrcopy, aws-ofi-nccl GIN + #1351, DeepEP-V2, pinned vLLM wheel) | `Dockerfile` Layer 5c: `pip install --no-deps ai-dynamo{,-runtime}==1.3.1` |
+| `Dockerfile` Layers 1–5b (NGC base, EFA, torch cu13, gdrcopy, aws-ofi-nccl GIN v1.21.1, DeepEP-V2, pinned vLLM wheel) | `Dockerfile` Layer 5c: `pip install --no-deps ai-dynamo{,-runtime}==1.3.1` |
 | `setup_deepep_v2_efa.sh`, `recipe/build_deepep.sh`, `recipe/run-kernel-test.sh`, `recipe/verify-image.sh`, `recipe/benchmark*.{sh,py}` | `recipe/serve.sh`: launches `dynamo.frontend` + `dynamo.vllm` (vs `vllm serve`) |
 | The proxy-Gin/EFA env contract, the DP-coordinator flags, the model, the EP-divisibility preflight | `kubernetes/dynamo-deepep-v2-2node.yaml`: readiness probe + names |
 
@@ -50,10 +50,12 @@ non-obvious integration fixes, not config:
    collective on the EP group before `ElasticBuffer` construction, so `_comm_ptr()` returns `0` →
    `ncclTeamWorld(nullptr)` → deterministic segfault on all ranks. Setting `0` restores DeepEP's
    create-own-comm path. (Env, set in `recipe/serve.sh` and `kubernetes/`.)
-2. **The gdrcopy forced-PCIe capability** for the GIN plugin on gdrdrv-2.4 hosts, via
-   `OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1` — the parameterized fix from
-   [aws/aws-ofi-nccl#1351](https://github.com/aws/aws-ofi-nccl/pull/1351), cherry-picked at a pinned SHA
-   in `setup_deepep_v2_efa.sh` (no local patch file).
+2. **gdrcopy compiled into the GIN plugin, with gdrdrv ≥ 2.5 on the host.** aws-ofi-nccl is built
+   from source at the released `v1.21.1` tag with `--with-gdrcopy`, and the build asserts gdrcopy
+   support landed (a gdrapi-less plugin fails `nccl_ofi_gin_init` at serve). The release attempts
+   the forced-PCIe pin path by default and falls back on failure, so no
+   `OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY` override is needed; the gdrdrv **kernel module ≥ 2.5** is a
+   host prerequisite instead (see Prerequisites).
 3. **DeepEP-V2 source** = the
    [`amazon-contributing/DeepEP`](https://github.com/amazon-contributing/DeepEP) fork at a pinned SHA
    (`97d8f9bc`) — the same source the repo's canonical V2/GIN provisioner pins ("the benchmark
@@ -99,6 +101,12 @@ At this pin, default (non-eager) compilation crashes deterministically ~48 s int
 
 - An EKS cluster of p5en.48xlarge (H200) with EFA + the EFA K8s device plugin (the shipped launcher);
   the container also runs under raw `docker run` on any 2 EFA hosts if you wire the rendezvous by hand.
+- The **`gdrdrv` kernel module ≥ 2.5 loaded on the host** (`cat /sys/module/gdrdrv/version`;
+  `/dev/gdrdrv` must exist). GIN needs GDRCopy at run time; the manifest's `privileged: true` lets the
+  container open the host's `/dev/gdrdrv`, but privileged cannot conjure the device node if the module
+  was never loaded — and the shipped plugin (released `v1.21.1`) carries no gdrdrv-2.4 workaround. The
+  AWS GPU AMIs ship it; if absent, `sudo modprobe gdrdrv` (gdrcopy ≥ 2.5, matching the image's
+  `c91ad9f`/v2.5.2 userspace build).
 - An ECR repo you own (set in `setup/env_vars`); this sample never hardcodes a registry.
 - Hugging Face access for the model (`Qwen/Qwen3-30B-A3B-FP8` is public, no token required).
 
@@ -110,7 +118,7 @@ bash setup/build-push.sh
 ```
 
 The image is NGC-from-scratch (`FROM nvcr.io/nvidia/cuda:...`). `setup_deepep_v2_efa.sh` builds
-aws-ofi-nccl (GIN + the #1351 param) and stages DeepEP-V2 source; the `_C.so` is compiled in-pod on
+aws-ofi-nccl (GIN, released `v1.21.1`) and stages the DeepEP-V2 source; the `_C.so` is compiled in-pod on
 first boot (needs a live CUDA context) by `recipe/`-invoked `build_deepep.sh`. Dynamo is added in
 Layer 5c as `pip install --no-deps ai-dynamo{,-runtime}==1.3.1` — `--no-deps` is load-bearing: without
 it, pip would pull `ai-dynamo`'s `vllm[...]==0.23.0` dependency and overwrite the pinned `VLLM_SHA`
@@ -250,18 +258,16 @@ eager and non-eager tables + environment provenance.
   EFA under a Dynamo front, not those higher-level Dynamo features.
 - `setup_deepep_v2_efa.sh` is a **documented variant** of the repo's canonical V2/GIN provisioner,
   [`micro-benchmarks/expert-parallelism/deepep-v2-benchmark/setup_deepep_gin.sh`](../../../../micro-benchmarks/expert-parallelism/deepep-v2-benchmark/setup_deepep_gin.sh)
-  (which appeared 2026-08-24). When the canonical moves, that is the file to track. Three deliberate
+  (which appeared 2026-08-24). When the canonical moves, that is the file to track. Two deliberate
   divergences justify a separate script here; the next reader should know they are choices, not drift:
-  1. **The unmerged aws-ofi-nccl #1351 parameter.** This sample cherry-picks
-     [aws/aws-ofi-nccl#1351](https://github.com/aws/aws-ofi-nccl/pull/1351)
-     (`OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY`) at a pinned head SHA; the canonical builds a stock GIN NCCL
-     and does not carry it. Until #1351 merges, this recipe cannot be a thin call into the canonical.
-  2. **CPU-proxy (`NCCL_GIN_TYPE=2`), not EFA-GDA.** This is the GDAKI-off, CPU-proxy transport that is
+  1. **CPU-proxy (`NCCL_GIN_TYPE=2`), not EFA-GDA.** This is the GDAKI-off, CPU-proxy transport that is
      viable on EFA today; the canonical benchmark's defaults and NCCL build target a different point in
      that design space.
-  3. **Coupling to the vLLM wheel's torch/NCCL ABI.** The DeepEP `_C.so` here is built in-pod against
+  2. **Coupling to the vLLM wheel's torch/NCCL ABI.** The DeepEP `_C.so` here is built in-pod against
      the exact `torch 2.11+cu130` / `nvidia-nccl-cu13 2.30.4` the pinned vLLM wheel drags in (Dockerfile
      Layer 5b re-pins it), so the toolchain is wheel-driven rather than a standalone NCCL build tree.
+     (The aws-ofi-nccl plugin itself is the canonical's version — released `v1.21.1`, built from source
+     so gdrcopy support is compiled in by construction.)
 
   The **DeepEP source** matches the canonical: both pin the
   [`amazon-contributing/DeepEP`](https://github.com/amazon-contributing/DeepEP) fork — this sample at

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/benchmarks/README.md
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/benchmarks/README.md
@@ -1,0 +1,108 @@
+<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0 -->
+# Benchmarks — vLLM + DeepEP-V2 over EFA
+
+Concurrency sweep of the live DP16/EP16 serve, same pods / same day / same probe. `recipe/benchmark.sh`
+fires N concurrent `/v1/chat/completions` per level and reports aggregate output tok/s + per-request
+latency percentiles. Raw JSONL lands in `raw/` (gitignored).
+
+The **eager** table below is the shipped, supported path (`SERVE_ENFORCE_EAGER=1`) and was measured on
+the **shipped pin** (`e2f993dc4`), so a stock rebuild of this sample reproduces it. The **non-eager**
+table is **historical**: it needed [vLLM #52632](https://github.com/vllm-project/vllm/pull/52632) applied
+as an unmerged cherry-pick (that guard is only on the 0.26 line, which regresses `deepep_v2` combine here
+— see the main README "eager vs non-eager"), so a stock rebuild does **not** reproduce it. It is kept for
+the eager-vs-non-eager comparison, not as a path this sample ships.
+
+## Environment provenance
+
+| | |
+|---|---|
+| Instance | 2× p5en.48xlarge (H200), cross-node EFA |
+| Transport | DeepEP-V2 `ElasticBuffer`, NCCL-GIN CPU-proxy (`NCCL_GIN_TYPE=2`, `OFI_NCCL_GIN_GDAKI=0`), `efa-direct` |
+| Model | `Qwen/Qwen3-30B-A3B-FP8`, DP16/EP16 (`--enable-expert-parallel --all2all-backend deepep_v2`) |
+| vLLM | `0.22.1rc1.dev283+ge2f993dc4` — the merge commit of [PR#41183](https://github.com/vllm-project/vllm/pull/41183) (first, and only measured-working, `deepep_v2` backend). **This is the shipped `Dockerfile` pin**, so a rebuild reproduces the eager table. (The non-eager table additionally needed #52632 as an unmerged cherry-pick — see below.) |
+| Stack | torch 2.11.0+cu130, nvidia-nccl-cu13 2.30.4, DeepEP `b306af06`+PR#612, aws-ofi-nccl GIN `9c44d34`+#1351 |
+| Serve fingerprint | `vllm-0.22.1rc1.dev283+ge2f993dc4-dp16-ep-1f3ed125` |
+| Probe | stdlib urllib+threads, 127.0.0.1 loopback, `max_tokens=128`, `temperature=0.0` (greedy), concurrency 1/8/16/32/64, **one shot per level** (N requests at concurrency N), identical prompt every request |
+| QP knobs | `EP_EFA_MAX_QPS=2`, `EP_EFA_RDMA_GBS=25.0` (serve.sh defaults — DeepEP PR#612's conservative EFA cap; see the note in serve.sh) |
+| Date | 2026-08-14 |
+
+**Probe methodology caveats for these tables** (the checked-in `recipe/benchmark_probe.py` has
+since been upgraded — see below — so a re-run will NOT reproduce these tables exactly):
+
+- **One shot per level**: at `conc=1` the "percentiles" are a single observation (visible above:
+  p50 = wall exactly). Rows describe one batch of N concurrent requests, not a distribution.
+- **Identical prompt, temperature 0**: vLLM's prefix cache serves every prompt after the first, so
+  prefill is ~free — these are **decode-focused** numbers, not end-to-end serving numbers.
+- **No `ignore_eos`**: the 128-token cap happened to bind for this prompt+model (4.8 × 26.91 ≈ 129),
+  so the denominator was stable here, but the harness did not enforce it.
+
+The current `recipe/benchmark_probe.py` fixes all three (5× requests per level so percentiles are
+distributions; a unique prompt prefix per request so prefix-cache can't serve prefill;
+`ignore_eos: true` pinning tokens = `max_tokens`; failures excluded from percentiles/throughput and
+failing the run). The new probe changes the sample count, the cache behaviour and the decode length,
+so the measured population differs — its numbers are **not directly comparable** to these tables;
+re-measure before quoting.
+
+## Results
+
+**What these tables are:** one concurrency sweep of the same backend per mode — the two endpoints
+of each sweep are NOT a before/after comparison. In the **eager** sweep per-stream rate stays pinned
+at ~4.75 tok/s while aggregate scales ≈ concurrency × constant (4.8 → 301.8 tok/s for 64× concurrency
+with wall flat at ~27 s), so no saturation point is reached. The **non-eager** sweep does show a
+wall-time rise at `conc=64` (26.61 → 34.18 s; per-stream 3.75 tok/s) — the one place in either sweep
+where the server is visibly under strain — while still stopping short of a measured saturation point.
+Read the numbers as the **DeepEP-V2-over-EFA per-stream latency floor at each concurrency**, not as a
+throughput ceiling — a saturation point was never measured (concurrency was not pushed until wall
+time rose across the whole sweep).
+
+### Eager (`--enforce-eager`; the shipped default, measured on the shipped pin `e2f993dc4` — a rebuild reproduces this) — 121/121 HTTP 200 (sweep = 1+8+16+32+64 requests)
+
+| conc | agg tok/s | wall s | p50 s | codes |
+|---|---|---|---|---|
+| 1 | 4.8 | 26.91 | 26.91 | 200 |
+| 8 | 37.1 | 27.63 | 27.63 | 200 |
+| 16 | 74.6 | 27.45 | 27.43 | 200 |
+| 32 | 151.9 | 26.97 | 26.95 | 200 |
+| 64 | 301.8 | 27.15 | 27.11 | 200 |
+
+### Non-eager (default compilation; historical — measured with the then-unmerged upstream guard, [vLLM #52632](https://github.com/vllm-project/vllm/pull/52632)) — sweep 121/121 HTTP 200
+
+| conc | agg tok/s | wall s | p50 s | codes |
+|---|---|---|---|---|
+| 1 | 5.0 | 25.48 | 25.48 | 200 |
+| 8 | 39.9 | 25.69 | 25.68 | 200 |
+| 16 | 76.9 | 26.64 | 26.19 | 200 |
+| 32 | 153.9 | 26.61 | 26.17 | 200 |
+| 64 | 239.7 | 34.18 | 33.91 | 200 |
+
+(The non-eager run's raw log totals 153/153 HTTP 200 = a 31-request warm-up ramp (1+2+4+8+16 at
+`max_tokens=8`) + 1 coherence check + the 121-request sweep above. The table rows are the sweep
+only — identical 121-request methodology to the eager table; the extra 32 requests were the
+run's warm/health phases, not extra sweep samples.)
+
+### Eager vs non-eager (agg tok/s; delta = non-eager relative to eager)
+
+| conc | eager | non-eager | delta |
+|---|---|---|---|
+| 1 | 4.8 | 5.0 | +4.2% |
+| 8 | 37.1 | 39.9 | +7.5% |
+| 16 | 74.6 | 76.9 | +3.1% |
+| 32 | 151.9 | 153.9 | +1.3% |
+| 64 | 301.8 | 239.7 | −20.6% (wall 27.15s → 34.18s) |
+
+**Reading:** non-eager matches-or-slightly-beats eager through concurrency 32, then falls ~21% behind at
+64 on this shape (the non-eager wall jumps 27→34 s at c=64 while eager stays flat). Mechanism not
+root-caused here — candidates are CUDA-graph capture-size coverage vs per-engine batch shape at high
+concurrency. Guidance: **eager is the shipped, supported, zero-patch path and is at worst ~a few percent
+off non-eager below c=64.** Non-eager is not a supported flip at the shipped pin (it needs #52632, which
+is only on the `deepep_v2`-combine-regressing 0.26 line — see the main README); the numbers above are the
+historical comparison, not a production option this sample offers.
+
+## Honest caveats
+
+- Pods were ~1 day old at measurement (accumulated-state can inflate latency; a fresh-pod baseline would
+  differ). Fixed 128-token greedy decode. **Single sweep per mode — no variance bars; the c=64 non-eager
+  delta was reproduced once.** These are at-scale **throughput + relative-latency** datapoints, not tuned
+  TTFT baselines: the ~26–34 s wall reflects 128-token generation, not a latency-optimized single token.
+- Both modes: 0 errors, 0 crashes, all HTTP 200. `raw/` holds the per-level JSONL from the sweeps.
+- No alternative-backend baseline was measured: every table is `--all2all-backend deepep_v2`. The sweeps show the EFA path works and how it scales — not that it outperforms vLLM's default all-to-all on this hardware.

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/benchmarks/README.md
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/benchmarks/README.md
@@ -47,8 +47,11 @@ since been upgraded — see below — so a re-run will NOT reproduce these table
   p50 = wall exactly). Rows describe one batch of N concurrent requests, not a distribution.
 - **Identical prompt, temperature 0**: vLLM's prefix cache serves every prompt after the first, so
   prefill is ~free — these are **decode-focused** numbers, not end-to-end serving numbers.
-- **No `ignore_eos`**: the 128-token cap happened to bind for this prompt+model (4.8 × 26.91 ≈ 129),
-  so the denominator was stable here, but the harness did not enforce it.
+- **No `ignore_eos`**: the 128-token cap happened to bind for this prompt+model — every row is
+  consistent with exactly 128 × n output tokens (e.g. conc=16: 74.6 tok/s × 27.45 s = 2048 = 16 × 128;
+  a "4.8 × 26.91 ≈ 129" back-inference is just the 1-decimal rounding artifact) — so the denominator
+  was stable here, but the harness did not enforce it. The shipped probe both enforces it
+  (`ignore_eos`) and records `total_out_tok` per level in the JSONL, which is the number to cite.
 
 The current `recipe/benchmark_probe.py` fixes all three (5× requests per level so percentiles are
 distributions; a unique prompt prefix per request so prefix-cache can't serve prefill;

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/benchmarks/README.md
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/benchmarks/README.md
@@ -1,30 +1,44 @@
 <!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0 -->
-# Benchmarks — vLLM + DeepEP-V2 over EFA
+# Benchmarks: DeepEP-V2 over EFA (measured on the sibling vLLM sample's image)
 
-Concurrency sweep of the live DP16/EP16 serve, same pods / same day / same probe. `recipe/benchmark.sh`
-fires N concurrent `/v1/chat/completions` per level and reports aggregate output tok/s + per-request
-latency percentiles. Raw JSONL lands in `raw/` (gitignored).
+Concurrency sweep of a live DP16/EP16 serve — same pods / same day / same (earlier-revision) probe
+for both modes; the non-eager mode came from applying [vLLM #52632](https://github.com/vllm-project/vllm/pull/52632)
+**in-pod** (patch + engine restart in the same pods), not from a separate image. These tables were
+measured on the **sibling vLLM sample's image** (`vllm serve` — no Dynamo front in the loop), **not
+re-measured on this Dynamo image**; they are quoted here as the shared-substrate datapoint. The
+**shipped** `recipe/benchmark.sh` + probe fire a different population (concurrency × 5 requests per
+level, unique prompt prefixes, `ignore_eos` — see the methodology caveats), report aggregate output
+tok/s + per-request latency percentiles, and write raw JSONL under `raw/` (gitignored; when run
+in-pod, persist the raws with the `kubectl cp` step in the main README **before** deleting the pods).
 
 The **eager** table below is the shipped, supported path (`SERVE_ENFORCE_EAGER=1`) and was measured on
-the **shipped pin** (`e2f993dc4`), so a stock rebuild of this sample reproduces it. The **non-eager**
-table is **historical**: it needed [vLLM #52632](https://github.com/vllm-project/vllm/pull/52632) applied
+the **shipped pin** (`e2f993dc4`), but on the sibling vLLM sample's image and with an earlier revision
+of the probe (see the methodology caveats below). It is **not** re-measured on this Dynamo image, and
+the checked-in probe measures a different population, so a stock rebuild will **not** reproduce it. The
+**non-eager** table is **historical**: it needed [vLLM #52632](https://github.com/vllm-project/vllm/pull/52632) applied
 as an unmerged cherry-pick (that guard is only on the 0.26 line, which regresses `deepep_v2` combine here
-— see the main README "eager vs non-eager"), so a stock rebuild does **not** reproduce it. It is kept for
-the eager-vs-non-eager comparison, not as a path this sample ships.
+— see the main README "eager vs non-eager"), so a stock rebuild does **not** reproduce it either. Both
+are kept for the eager-vs-non-eager comparison, not as paths this sample ships.
 
 ## Environment provenance
+
+**Substrate numbers.** Everything below is the measured provenance of the *vLLM-image* runs; no
+request in these tables traversed `dynamo.frontend` or `dynamo.vllm`. Rows record the **resolved**
+values of that measurement (what was actually built and run), not the configured ones — where the
+current recipe has since diverged, the row says so.
 
 | | |
 |---|---|
 | Instance | 2× p5en.48xlarge (H200), cross-node EFA |
 | Transport | DeepEP-V2 `ElasticBuffer`, NCCL-GIN CPU-proxy (`NCCL_GIN_TYPE=2`, `OFI_NCCL_GIN_GDAKI=0`), `efa-direct` |
 | Model | `Qwen/Qwen3-30B-A3B-FP8`, DP16/EP16 (`--enable-expert-parallel --all2all-backend deepep_v2`) |
-| vLLM | `0.22.1rc1.dev283+ge2f993dc4` — the merge commit of [PR#41183](https://github.com/vllm-project/vllm/pull/41183) (first, and only measured-working, `deepep_v2` backend). **This is the shipped `Dockerfile` pin**, so a rebuild reproduces the eager table. (The non-eager table additionally needed #52632 as an unmerged cherry-pick — see below.) |
-| Stack | torch 2.11.0+cu130, nvidia-nccl-cu13 2.30.4, DeepEP `b306af06`+PR#612, aws-ofi-nccl GIN `9c44d34`+#1351 |
-| Serve fingerprint | `vllm-0.22.1rc1.dev283+ge2f993dc4-dp16-ep-1f3ed125` |
-| Probe | stdlib urllib+threads, 127.0.0.1 loopback, `max_tokens=128`, `temperature=0.0` (greedy), concurrency 1/8/16/32/64, **one shot per level** (N requests at concurrency N), identical prompt every request |
-| QP knobs | `EP_EFA_MAX_QPS=2`, `EP_EFA_RDMA_GBS=25.0` (serve.sh defaults — DeepEP PR#612's conservative EFA cap; see the note in serve.sh) |
-| Date | 2026-08-14 |
+| vLLM | `0.22.1rc1.dev283+ge2f993dc4` — the merge commit of [PR#41183](https://github.com/vllm-project/vllm/pull/41183) (first, and only measured-working, `deepep_v2` backend). **This is the shipped `Dockerfile` pin** — the vLLM substrate matches; the serving front and the rest of the stack do not (see the other rows). |
+| ai-dynamo | **none** — these tables predate the Dynamo front: measured via `vllm serve` on the sibling vLLM sample's image (no `dynamo.frontend`, no `dynamo.vllm`, no `--discovery-backend file`). This sample pins `ai-dynamo{,-runtime}==1.3.1`; producing Dynamo-fronted numbers is the queued re-measure (see Honest caveats). |
+| Stack | torch 2.11.0+cu130, nvidia-nccl-cu13 2.30.4, DeepEP `28d1f7fb` (the **effective** tree: the configured `b306af06` + PR#612 `git merge` fast-forwarded to it), aws-ofi-nccl `9c44d34` + [#1351](https://github.com/aws/aws-ofi-nccl/pull/1351) commit 1/2 (`c2e773df`). The **current recipe differs**: DeepEP = `amazon-contributing` fork @ `97d8f9bc`, aws-ofi-nccl = released `v1.21.1` — a further reason a rebuild does not reproduce these tables. |
+| Serve fingerprint | `vllm-0.22.1rc1.dev283+ge2f993dc4-dp16-ep-1f3ed125` (that run's vLLM engine fingerprint, recorded as-is; not reproducible from this sample) |
+| Probe | stdlib urllib+threads, 127.0.0.1 loopback, `max_tokens=128`, `temperature=0.0` (greedy), concurrency 1/8/16/32/64, **one shot per level** (N requests at concurrency N), identical prompt every request — an **earlier revision** of the checked-in probe (see caveats) |
+| QP knobs | `EP_EFA_MAX_QPS=2`, `EP_EFA_RDMA_GBS=25.0` — the serve defaults **at measurement time** (the deepseek tree's PR#612 knobs). The current recipe pins the `amazon-contributing` fork, which resolves QP count and link rate internally; neither env exists (or is set) in this sample any more. |
+| Date | 2026-08-14 — the vLLM-image measurement date (this PR's own Dynamo E2E evidence dates 2026-09-04) |
 
 **Probe methodology caveats for these tables** (the checked-in `recipe/benchmark_probe.py` has
 since been upgraded — see below — so a re-run will NOT reproduce these tables exactly):
@@ -55,7 +69,7 @@ Read the numbers as the **DeepEP-V2-over-EFA per-stream latency floor at each co
 throughput ceiling — a saturation point was never measured (concurrency was not pushed until wall
 time rose across the whole sweep).
 
-### Eager (`--enforce-eager`; the shipped default, measured on the shipped pin `e2f993dc4` — a rebuild reproduces this) — 121/121 HTTP 200 (sweep = 1+8+16+32+64 requests)
+### Eager (`--enforce-eager`; the shipped default, measured on the shipped pin `e2f993dc4` — on the sibling vLLM image, not this sample) — 121/121 HTTP 200 (sweep = 1+8+16+32+64 requests)
 
 | conc | agg tok/s | wall s | p50 s | codes |
 |---|---|---|---|---|
@@ -75,27 +89,37 @@ time rose across the whole sweep).
 | 32 | 153.9 | 26.61 | 26.17 | 200 |
 | 64 | 239.7 | 34.18 | 33.91 | 200 |
 
-(The non-eager run's raw log totals 153/153 HTTP 200 = a 31-request warm-up ramp (1+2+4+8+16 at
+(The non-eager run's raw log totaled 153/153 HTTP 200 = a 31-request warm-up ramp (1+2+4+8+16 at
 `max_tokens=8`) + 1 coherence check + the 121-request sweep above. The table rows are the sweep
 only — identical 121-request methodology to the eager table; the extra 32 requests were the
-run's warm/health phases, not extra sweep samples.)
+run's warm/health phases, not extra sweep samples. That log was not persisted off-pod — see
+Honest caveats. Note the asymmetry it creates: the non-eager sweep started against a **warm**
+server — 31 warm-up requests plus prefix caching over an identical prompt — while the eager
+sweep ran with no warm-up, which favors non-eager most at `conc=1`.)
 
 ### Eager vs non-eager (agg tok/s; delta = non-eager relative to eager)
 
-| conc | eager | non-eager | delta |
-|---|---|---|---|
-| 1 | 4.8 | 5.0 | +4.2% |
-| 8 | 37.1 | 39.9 | +7.5% |
-| 16 | 74.6 | 76.9 | +3.1% |
-| 32 | 151.9 | 153.9 | +1.3% |
-| 64 | 301.8 | 239.7 | −20.6% (wall 27.15s → 34.18s) |
+Deltas are computed from the underlying **wall times** (the same token total divides out), not from
+the 1-decimal rate column — at `conc=1` the rounded rates suggest +4.2% while the walls
+(26.91 s / 25.48 s) give the real **+5.6%**. Single sweep per mode, so each delta is a single
+observation: the sub-10% rows are **within run-to-run variation** (and carry the warm-cache
+asymmetry noted above, strongest at `conc=1`); only the −20.6% row at `conc=64` separates from noise.
 
-**Reading:** non-eager matches-or-slightly-beats eager through concurrency 32, then falls ~21% behind at
-64 on this shape (the non-eager wall jumps 27→34 s at c=64 while eager stays flat). Mechanism not
-root-caused here — candidates are CUDA-graph capture-size coverage vs per-engine batch shape at high
-concurrency. Guidance: **eager is the shipped, supported, zero-patch path and is at worst ~a few percent
-off non-eager below c=64.** Non-eager is not a supported flip at the shipped pin (it needs #52632, which
-is only on the `deepep_v2`-combine-regressing 0.26 line — see the main README); the numbers above are the
+| conc | eager | non-eager | delta (from walls) |
+|---|---|---|---|
+| 1 | 4.8 | 5.0 | +5.6% (single obs., within run-to-run variation; warm-cache-favored) |
+| 8 | 37.1 | 39.9 | +7.5% (single obs., within run-to-run variation) |
+| 16 | 74.6 | 76.9 | +3.1% (single obs., within run-to-run variation) |
+| 32 | 151.9 | 153.9 | +1.3% (single obs., within run-to-run variation) |
+| 64 | 301.8 | 239.7 | −20.6% (wall 27.15s → 34.18s — the one delta large enough to read) |
+
+**Reading:** non-eager is indistinguishable from eager through concurrency 32 (single-observation
+deltas within run-to-run variation), then falls ~21% behind at 64 on this shape (the non-eager wall
+jumps 27→34 s at c=64 while eager stays flat). Mechanism not root-caused here — candidates are
+CUDA-graph capture-size coverage vs per-engine batch shape at high concurrency. Guidance: **eager is
+the shipped, supported, zero-patch path and is at worst ~a few percent off non-eager below c=64.**
+Non-eager is not a supported flip at the shipped pin (it needs #52632, which is only on the
+`deepep_v2`-combine-regressing 0.26 line — see the main README); the numbers above are the
 historical comparison, not a production option this sample offers.
 
 ## Honest caveats
@@ -104,5 +128,9 @@ historical comparison, not a production option this sample offers.
   differ). Fixed 128-token greedy decode. **Single sweep per mode — no variance bars; the c=64 non-eager
   delta was reproduced once.** These are at-scale **throughput + relative-latency** datapoints, not tuned
   TTFT baselines: the ~26–34 s wall reflects 128-token generation, not a latency-optimized single token.
-- Both modes: 0 errors, 0 crashes, all HTTP 200. `raw/` holds the per-level JSONL from the sweeps.
+- Both modes: 0 errors, 0 crashes, all HTTP 200. **The per-level raw JSONLs were not persisted
+  off-pod** — they were written inside the pods' `emptyDir` and deleted with the pods, so these
+  tables cannot be re-audited against their raws. (That is why the main README's benchmark
+  procedure now ends with a `kubectl cp` persistence step.) The queued re-measure of this Dynamo
+  image on the updated recipe will produce a persisted, auditable set.
 - No alternative-backend baseline was measured: every table is `--all2all-backend deepep_v2`. The sweeps show the EFA path works and how it scales — not that it outperforms vLLM's default all-to-all on this hardware.

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/kubernetes/dynamo-deepep-v2-2node.yaml
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/kubernetes/dynamo-deepep-v2-2node.yaml
@@ -1,0 +1,211 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+# NVIDIA Dynamo (dynamo.frontend ingress + dynamo.vllm worker) + DeepEP-V2 multi-node MoE serve
+# over AWS EFA — 2× p5en.48xlarge (H200), DP16/EP16. This is the vLLM-DeepEP-V2 substrate
+# (../../vllm/deepep-v2-efa) with a Dynamo serving front; the DeepEP-V2/EFA transport is identical.
+#
+# Serving topology (see recipe/serve.sh header + README "Relationship to the vLLM sample"):
+#   pod-0 (leader): dynamo.frontend on :8000 (OpenAI HTTP) + dynamo.vllm (non-headless) DP ranks 0..7.
+#   pod-1+ (worker): dynamo.vllm --headless — vLLM run_headless(), joins the DP group via vLLM's
+#                    native data-parallel RPC to the leader (no discovery/etcd/NATS).
+#   The OpenAI API is served ONLY by pod-0 — address vllm... the leader pod directly (see Service note).
+#
+# Scale seams (no other change needed — measured EP16→EP32 was launcher-args only):
+#   4 nodes / EP32:  replicas: 4  +  SERVE_DP "32"          (worker start-ranks derive from ordinal)
+#   other instance types (per-node EFA NIC count differs):
+#     p5.48xlarge  (H100): vpc.amazonaws.com/efa: "32", nodeSelector p5.48xlarge
+#     p5en.48xlarge(H200): vpc.amazonaws.com/efa: "16"  ← this file
+#     p6-b200.48xlarge   : vpc.amazonaws.com/efa: "8",  and set DEEPEP_ARCH_LIST=10.0 (env below)
+#     p6-b300.48xlarge   : vpc.amazonaws.com/efa: "16", and set DEEPEP_ARCH_LIST=10.3 (env below).
+#       NOTE (B300): the pinned vLLM wheel carries no sm_103 SASS (sm_75..90a/100/120, PTX to
+#       sm_90) — B300 runs on sm_100 SASS compatibility; the in-pod DeepEP build is native 10.3.
+#
+# Image: build the sample-root Dockerfile (NGC-from-scratch, public sources only) and push to
+# YOUR registry — setup/build-push.sh builds ${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} from
+# setup/env_vars; set image: below to that SAME name. Do NOT point at anyone's private registry.
+#
+# privileged: true is REQUIRED where /dev/gdrdrv is not advertised by a device plugin
+# (measured 2026-08-01: the unprivileged device cgroup blocks open("/dev/gdrdrv") with
+# EPERM even after CAP_MKNOD + chmod; only privileged allow-all-devices passes; the
+# CPU-proxy GIN path needs gdrcopy). If your cluster runs a gdrdrv device plugin, drop
+# privileged and request the device instead.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dynamo-deepep
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dynamo-deepep-v2
+  namespace: dynamo-deepep
+spec:
+  clusterIP: None            # headless — stable per-pod DNS for the DP rendezvous
+  # publishNotReadyAddresses pairs with the container readinessProbe below: workers
+  # resolve the leader through this Service's DNS A-record BEFORE the leader is Ready, so the
+  # not-ready leader address must still publish or the rendezvous deadlocks.
+  publishNotReadyAddresses: true
+  selector:
+    app: dynamo-deepep-v2
+  ports:
+  - { port: 29500, name: dp-rpc }
+  - { port: 8000,  name: http }   # NOTE: headless + publishNotReadyAddresses => this name also resolves to workers (--headless, no HTTP server) and to a not-yet-ready leader. Address the leader pod directly (dynamo-deepep-v2-0) for the OpenAI API.
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dynamo-deepep-v2
+  namespace: dynamo-deepep
+spec:
+  serviceName: dynamo-deepep-v2
+  replicas: 2                # 2 nodes = DP16/EP16 ; 4 nodes = DP32/EP32 (also set SERVE_DP)
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app: dynamo-deepep-v2
+  template:
+    metadata:
+      labels:
+        app: dynamo-deepep-v2
+    spec:
+      # one pod per node — EFA/GPU are node resources; same-node EFA loopback is
+      # silently dropped by SRD anyway, so co-scheduling two pods is never right
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: dynamo-deepep-v2
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        node.kubernetes.io/instance-type: p5en.48xlarge
+      tolerations:
+      - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: dynamo
+        image: REPLACE_WITH_YOUR_REGISTRY/dynamo-deepep-v2-efa:v2-20260904   # = ${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} from setup/env_vars — bump on every rebuild (IfNotPresent caches by tag). Keep in sync with setup/env_vars.example.
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          set -euo pipefail   # -e: a failed DeepEP build must STOP startup here, not
+                              # surface later as an opaque vLLM import error
+          echo "=== Dynamo DeepEP-V2 guide pod $(hostname) $(date -u +%FT%TZ) ==="
+          echo "DeepEP effective SHA: $(cat /opt/deepep.effective.sha 2>/dev/null || echo unknown)"
+
+          # 1) DeepEP-V2 _C.so — built ONCE per pod (needs the live CUDA context;
+          #    that is why it is not baked into the image). ~2 min. Idempotent guard.
+          python3 -c "import deep_ep" 2>/dev/null || bash /opt/build_deepep.sh
+
+          # 2) resolve the leader (pod ordinal 0) through headless-service DNS
+          ORDINAL=${HOSTNAME##*-}
+          LEADER_DNS="dynamo-deepep-v2-0.dynamo-deepep-v2.dynamo-deepep.svc.cluster.local"
+          for i in $(seq 1 120); do getent hosts "$LEADER_DNS" >/dev/null 2>&1 && break; sleep 1; done
+          LEADER_IP=$(getent hosts "$LEADER_DNS" | awk '{print $1}' | head -1 || true)
+          test -n "$LEADER_IP" || { echo "FATAL: leader DNS $LEADER_DNS never resolved"; exit 1; }
+          echo "=== ordinal=$ORDINAL leader=$LEADER_IP ==="
+
+          # 3) serve — leader on ordinal 0, workers derive start-rank from ordinal
+          #    x SERVE_DP_LOCAL (the GPUs-per-node knob — keep manifest + serve.sh consistent).
+          #    Ordering is NOT enforced here: podManagementPolicy: Parallel starts both pods
+          #    together and the worker's only gate is the leader's DNS record (published early
+          #    by publishNotReadyAddresses), so a worker can reach serve.sh before the leader
+          #    binds :29500. vLLM's DP rendezvous tolerates this by retrying (observed across
+          #    our bring-up runs); if you see a rendezvous timeout, add a connect-check on the
+          #    leader's :29500 before this exec rather than relying on start order.
+          if [ "$ORDINAL" = "0" ]; then
+            exec bash /opt/serve.sh leader "$LEADER_IP"
+          else
+            exec bash /opt/serve.sh worker "$LEADER_IP" $((ORDINAL * ${SERVE_DP_LOCAL:-8}))
+          fi
+        env:
+        # ---- scale + model (the knobs; defaults = measured EP16 shape) ----
+        - { name: SERVE_DP,       value: "16" }     # total DP = EP size; 32 for 4 nodes
+        - { name: SERVE_DP_LOCAL, value: "8" }      # GPUs per node — worker start-ranks derive from this
+        - { name: SERVE_MODEL, value: "Qwen/Qwen3-30B-A3B-FP8" }  # any MoE with n_routed_experts % DP == 0 (serve.sh asserts)
+        # - { name: SERVE_ENFORCE_EAGER, value: "1" }   # 1 = eager (the shipped default + only supported mode at this pin); 0 = default compilation, which crashes at this pin (needs vLLM #52632, only on the deepep_v2-regressing 0.26 line — README "eager vs non-eager"). Leave unset/1.
+        # - { name: DEEPEP_ARCH_LIST, value: "10.0" }   # in-pod DeepEP build arch; default 9.0 = H100/H200 — set 10.0 on p6-b200, 10.3 on p6-b300 (Blackwell)
+        # - { name: HF_TOKEN, valueFrom: { secretKeyRef: { name: hf-token, key: token } } }  # gated models only
+
+        # ---- proxy-Gin + EFA contract, VERBATIM (also baked as image ENV; repeated
+        #      here so the manifest alone documents the transport contract) ----
+        - { name: NCCL_GIN_TYPE,             value: "2" }     # 2 = CPU-proxy GIN (the EFA-viable path)
+        - { name: NCCL_GIN_ENABLE,           value: "1" }
+        - { name: OFI_NCCL_GIN_GDAKI,        value: "0" }     # GPU-initiated: not the shipped path on EFA
+        - { name: OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY, value: "1" }  # aws-ofi-nccl PR#1351 (baked in setup_deepep_v2_efa.sh)
+        - { name: EP_REUSE_NCCL_COMM,        value: "0" }     # DeepEP own-comm; never borrow torch lazy comm (2026-08-14 fix)
+        - { name: OFI_NCCL_GIN_MAX_REQUESTS, value: "512" }
+        - { name: NCCL_CUMEM_ENABLE,         value: "1" }
+        - { name: NCCL_NVLS_ENABLE,          value: "0" }
+        - { name: NCCL_IGNORE_DISABLED_P2P,  value: "1" }
+        - { name: FI_PROVIDER,               value: "efa" }
+        - { name: FI_EFA_USE_DEVICE_RDMA,    value: "1" }
+        - { name: FI_EFA_ENABLE_SHM_TRANSFER, value: "0" }
+        - { name: FI_EFA_FORK_SAFE,          value: "1" }
+        - { name: OFI_NCCL_PROTOCOL,         value: "RDMA" }
+        - { name: DEEP_EP_BACKEND,           value: "nccl" }
+        - { name: NCCL_NET_PLUGIN,           value: "/opt/aws-ofi-nccl/lib/libnccl-net-ofi.so" }
+        - { name: NCCL_DEBUG,                value: "WARN" }  # INFO to see the efa-direct banner proof
+        # ---- readiness (see README "Readiness on Dynamo — why /health alone lies") ----
+        # LEADER (ordinal 0): dynamo.frontend's /health returns 200 as soon as the HTTP server
+        # binds (~6 s) — its ServiceObserver defaults to Ready and nothing flips it on engine
+        # registration, so a bare `curl /health` would report Ready with NO engine, hours before
+        # the model is loaded. The engine registers with the frontend ONLY after the weight load
+        # (dynamo.vllm register_model() runs after AsyncLLM.from_vllm_config), and once it does the
+        # /health body's "endpoints"/"instances" arrays become non-empty. So the honest probe is
+        # "/health is 200 AND has ≥1 endpoint" — `grep -qF '"endpoints":["'` (matches only a
+        # populated array). The failureThreshold budget below then genuinely bounds compile + load.
+        # WORKER (ordinal 1+): --headless, no HTTP server and it never registers a discovery
+        # endpoint, so its probe is process-liveness only — `pgrep -f dynamo.vllm`. `dynamo.vllm`
+        # exists from launch, so a worker's startupProbe passes on its first tick (the 60-min budget
+        # does not apply to a worker) and a wedged-but-alive worker stays Ready. This is a known
+        # limitation, not a readiness check — a worker's true progress is observed via the leader
+        # coming Ready (the DP rendezvous cannot complete, and the leader cannot register an engine,
+        # without every worker). Pairs with publishNotReadyAddresses (workers need the leader DNS
+        # record BEFORE it is Ready, or the rendezvous deadlocks).
+        startupProbe:
+          exec:
+            command: ["/bin/bash", "-c", "if [ \"${HOSTNAME##*-}\" = \"0\" ]; then curl -sf http://127.0.0.1:8000/health | grep -qF '\"endpoints\":[\"'; else pgrep -f '[d]ynamo.vllm' >/dev/null; fi"]
+          periodSeconds: 30
+          timeoutSeconds: 5                  # exec probes default to 1s; a busy /health can exceed it -> false failure
+          failureThreshold: 120              # up to 60 min: in-pod compile + multi-hundred-GB model load + engine registration
+        readinessProbe:
+          exec:
+            command: ["/bin/bash", "-c", "if [ \"${HOSTNAME##*-}\" = \"0\" ]; then curl -sf http://127.0.0.1:8000/health | grep -qF '\"endpoints\":[\"'; else pgrep -f '[d]ynamo.vllm' >/dev/null; fi"]
+          periodSeconds: 15
+          timeoutSeconds: 5                  # as above — prevents readiness flapping on the leader under load
+        # requests == limits (Guaranteed QoS): NCCL_GIN_TYPE=2 is the CPU-PROXY path, so
+        # proxy-thread CPU sits on the data path — Burstable QoS + CFS throttling under node
+        # pressure would degrade network throughput and silently taint published numbers.
+        resources:
+          limits:
+            nvidia.com/gpu: "8"
+            vpc.amazonaws.com/efa: "16"      # p5en=16, p5=32, p6-b200=8
+            hugepages-2Mi: 5120Mi          # needs 2Mi hugepages pre-allocated on the node (they were on the nodes the measured runs used; without them the pod sits Pending)
+            cpu: "90"
+            memory: 1024Gi
+          requests:
+            nvidia.com/gpu: "8"
+            vpc.amazonaws.com/efa: "16"
+            hugepages-2Mi: 5120Mi
+            cpu: "90"
+            memory: 1024Gi
+        securityContext:
+          privileged: true                   # gdrdrv device-cgroup (see header)
+          capabilities:
+            add: [IPC_LOCK]                  # RDMA memory pinning
+        ports:
+        - { containerPort: 8000,  name: http }
+        - { containerPort: 29500, name: dp-rpc }
+        volumeMounts:
+        - { name: shm,            mountPath: /dev/shm }
+        - { name: dev-infiniband, mountPath: /dev/infiniband }
+        - { name: work,           mountPath: /work }     # HF cache + logs (per-pod, ephemeral)
+      volumes:
+      - name: shm
+        emptyDir: { medium: Memory, sizeLimit: 128Gi }
+      - name: dev-infiniband
+        hostPath: { path: /dev/infiniband }
+      - name: work
+        emptyDir: { sizeLimit: 900Gi }       # big MoE weights land here; size for your model

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/kubernetes/dynamo-deepep-v2-2node.yaml
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/kubernetes/dynamo-deepep-v2-2node.yaml
@@ -123,7 +123,7 @@ spec:
         # ---- scale + model (the knobs; defaults = measured EP16 shape) ----
         - { name: SERVE_DP,       value: "16" }     # total DP = EP size; 32 for 4 nodes
         - { name: SERVE_DP_LOCAL, value: "8" }      # GPUs per node — worker start-ranks derive from this
-        - { name: SERVE_MODEL, value: "Qwen/Qwen3-30B-A3B-FP8" }  # any MoE with n_routed_experts % DP == 0 (serve.sh asserts)
+        - { name: SERVE_MODEL, value: "Qwen/Qwen3-30B-A3B-FP8" }  # any MoE with n_routed_experts % (DP x TP) == 0 (serve.sh asserts)
         # - { name: SERVE_ENFORCE_EAGER, value: "1" }   # 1 = eager (the shipped default + only supported mode at this pin); 0 = default compilation, which crashes at this pin (needs vLLM #52632, only on the deepep_v2-regressing 0.26 line — README "eager vs non-eager"). Leave unset/1.
         # - { name: DEEPEP_ARCH_LIST, value: "10.0" }   # in-pod DeepEP build arch; default 9.0 = H100/H200 — set 10.0 on p6-b200, 10.3 on p6-b300 (Blackwell)
         # - { name: HF_TOKEN, valueFrom: { secretKeyRef: { name: hf-token, key: token } } }  # gated models only

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/kubernetes/dynamo-deepep-v2-2node.yaml
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/kubernetes/dynamo-deepep-v2-2node.yaml
@@ -60,6 +60,8 @@ spec:
   serviceName: dynamo-deepep-v2
   replicas: 2                # 2 nodes = DP16/EP16 ; 4 nodes = DP32/EP32 (also set SERVE_DP)
   podManagementPolicy: Parallel
+  updateStrategy:
+    type: OnDelete           # a one-shot DP rendezvous cannot be rolled one pod at a time; recovery is `kubectl delete pod -l app=dynamo-deepep-v2` (all pods together — see README "Update / recovery")
   selector:
     matchLabels:
       app: dynamo-deepep-v2
@@ -128,8 +130,9 @@ spec:
         # - { name: DEEPEP_ARCH_LIST, value: "10.0" }   # in-pod DeepEP build arch; default 9.0 = H100/H200 — set 10.0 on p6-b200, 10.3 on p6-b300 (Blackwell)
         # - { name: HF_TOKEN, valueFrom: { secretKeyRef: { name: hf-token, key: token } } }  # gated models only
 
-        # ---- proxy-Gin + EFA contract, VERBATIM (also baked as image ENV; repeated
-        #      here so the manifest alone documents the transport contract) ----
+        # ---- proxy-Gin + EFA contract, VERBATIM (also exported by recipe/serve.sh; repeated
+        #      here so the manifest alone documents the transport contract — the Dockerfile
+        #      deliberately bakes none of it) ----
         - { name: NCCL_GIN_TYPE,             value: "2" }     # 2 = CPU-proxy GIN (the EFA-viable path)
         - { name: NCCL_GIN_ENABLE,           value: "1" }
         - { name: OFI_NCCL_GIN_GDAKI,        value: "0" }     # GPU-initiated: not the shipped path on EFA
@@ -145,7 +148,8 @@ spec:
         - { name: OFI_NCCL_PROTOCOL,         value: "RDMA" }
         - { name: DEEP_EP_BACKEND,           value: "nccl" }
         - { name: NCCL_NET_PLUGIN,           value: "/opt/aws-ofi-nccl/lib/libnccl-net-ofi.so" }
-        - { name: NCCL_DEBUG,                value: "WARN" }  # INFO to see the efa-direct banner proof
+        - { name: NCCL_SOCKET_IFNAME,        value: "^lo,docker,veth" }  # exclusion list (serve.sh honors an override) — auto-select can pick a non-routing iface -> rendezvous hang
+        - { name: SERVE_NCCL_DEBUG,          value: "WARN" }  # INFO to see the efa-direct banner proof (serve.sh reads SERVE_NCCL_DEBUG, not NCCL_DEBUG)
         # ---- readiness (see README "Readiness on Dynamo — why /health alone lies") ----
         # LEADER (ordinal 0): dynamo.frontend's /health returns 200 as soon as the HTTP server
         # binds (~6 s) — its ServiceObserver defaults to Ready and nothing flips it on engine
@@ -153,8 +157,12 @@ spec:
         # the model is loaded. The engine registers with the frontend ONLY after the weight load
         # (dynamo.vllm register_model() runs after AsyncLLM.from_vllm_config), and once it does the
         # /health body's "endpoints"/"instances" arrays become non-empty. So the honest probe is
-        # "/health is 200 AND has ≥1 endpoint" — `grep -qF '"endpoints":["'` (matches only a
-        # populated array). The failureThreshold budget below then genuinely bounds compile + load.
+        # "/health is 200 AND has ≥1 endpoint" — checked STRUCTURALLY (python3 json.load, non-empty
+        # "endpoints") rather than a substring match, so a serialization change across a Dynamo bump
+        # cannot make the probe lie. The startupProbe budget is aligned to serve.sh's
+        # VLLM_ENGINE_READY_TIMEOUT_S=1800: the ENGINE's 30-min timeout is the real budget and fires
+        # first (its error names the cause); the probe allows +5 min for the pre-engine steps
+        # (in-pod DeepEP build, DNS wait). Raise BOTH knobs together for a bigger model.
         # WORKER (ordinal 1+): --headless, no HTTP server and it never registers a discovery
         # endpoint, so its probe is process-liveness only — `pgrep -f dynamo.vllm`. `dynamo.vllm`
         # exists from launch, so a worker's startupProbe passes on its first tick (the 60-min budget
@@ -165,15 +173,29 @@ spec:
         # record BEFORE it is Ready, or the rendezvous deadlocks).
         startupProbe:
           exec:
-            command: ["/bin/bash", "-c", "if [ \"${HOSTNAME##*-}\" = \"0\" ]; then curl -sf http://127.0.0.1:8000/health | grep -qF '\"endpoints\":[\"'; else pgrep -f '[d]ynamo.vllm' >/dev/null; fi"]
+            command: ["/bin/bash", "-c", "if [ \"${HOSTNAME##*-}\" = \"0\" ]; then curl -sf http://127.0.0.1:8000/health | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get(\"endpoints\") else 1)'; else pgrep -f '[d]ynamo.vllm' >/dev/null; fi"]
           periodSeconds: 30
           timeoutSeconds: 5                  # exec probes default to 1s; a busy /health can exceed it -> false failure
-          failureThreshold: 120              # up to 60 min: in-pod compile + multi-hundred-GB model load + engine registration
+          failureThreshold: 70               # 35 min = VLLM_ENGINE_READY_TIMEOUT_S (1800 s, serve.sh) + 5 min pre-engine margin — see the budget note above
         readinessProbe:
           exec:
-            command: ["/bin/bash", "-c", "if [ \"${HOSTNAME##*-}\" = \"0\" ]; then curl -sf http://127.0.0.1:8000/health | grep -qF '\"endpoints\":[\"'; else pgrep -f '[d]ynamo.vllm' >/dev/null; fi"]
+            command: ["/bin/bash", "-c", "if [ \"${HOSTNAME##*-}\" = \"0\" ]; then curl -sf http://127.0.0.1:8000/health | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get(\"endpoints\") else 1)'; else pgrep -f '[d]ynamo.vllm' >/dev/null; fi"]
           periodSeconds: 15
           timeoutSeconds: 5                  # as above — prevents readiness flapping on the leader under load
+        # Leader liveness: same exec as readiness, VERBATIM — the startupProbe above gates it, so it
+        # cannot fire during the compile/load. Catches frontend death (the leader otherwise stays
+        # NotReady-but-running forever while publishNotReadyAddresses keeps publishing it) and a
+        # wedged leader. A restarted leader cannot be rejoined by live workers (the DP rendezvous is
+        # one-shot) — recovery is the all-pods delete this file's updateStrategy comment and the
+        # README "Update / recovery" section name. On a worker the pgrep half is plain process
+        # liveness, which the container's exec-ed serve already provides; the probe is uniform for
+        # the same reason the readiness one is.
+        livenessProbe:
+          exec:
+            command: ["/bin/bash", "-c", "if [ \"${HOSTNAME##*-}\" = \"0\" ]; then curl -sf http://127.0.0.1:8000/health | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get(\"endpoints\") else 1)'; else pgrep -f '[d]ynamo.vllm' >/dev/null; fi"]
+          periodSeconds: 15
+          timeoutSeconds: 5
+          failureThreshold: 4                # ~1 min of consecutive failure before the restart
         # requests == limits (Guaranteed QoS): NCCL_GIN_TYPE=2 is the CPU-PROXY path, so
         # proxy-thread CPU sits on the data path — Burstable QoS + CFS throttling under node
         # pressure would degrade network throughput and silently taint published numbers.
@@ -205,6 +227,6 @@ spec:
       - name: shm
         emptyDir: { medium: Memory, sizeLimit: 128Gi }
       - name: dev-infiniband
-        hostPath: { path: /dev/infiniband }
+        hostPath: { path: /dev/infiniband, type: Directory }   # fail at mount time on a non-EFA node, not inside NCCL with the devices unnamed
       - name: work
         emptyDir: { sizeLimit: 900Gi }       # big MoE weights land here; size for your model

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/kubernetes/dynamo-deepep-v2-2node.yaml
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/kubernetes/dynamo-deepep-v2-2node.yaml
@@ -133,7 +133,6 @@ spec:
         - { name: NCCL_GIN_TYPE,             value: "2" }     # 2 = CPU-proxy GIN (the EFA-viable path)
         - { name: NCCL_GIN_ENABLE,           value: "1" }
         - { name: OFI_NCCL_GIN_GDAKI,        value: "0" }     # GPU-initiated: not the shipped path on EFA
-        - { name: OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY, value: "1" }  # aws-ofi-nccl PR#1351 (baked in setup_deepep_v2_efa.sh)
         - { name: EP_REUSE_NCCL_COMM,        value: "0" }     # DeepEP own-comm; never borrow torch lazy comm (2026-08-14 fix)
         - { name: OFI_NCCL_GIN_MAX_REQUESTS, value: "512" }
         - { name: NCCL_CUMEM_ENABLE,         value: "1" }

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/kubernetes/dynamo-deepep-v2-2node.yaml
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/kubernetes/dynamo-deepep-v2-2node.yaml
@@ -197,8 +197,10 @@ spec:
           timeoutSeconds: 5
           failureThreshold: 4                # ~1 min of consecutive failure before the restart
         # requests == limits (Guaranteed QoS): NCCL_GIN_TYPE=2 is the CPU-PROXY path, so
-        # proxy-thread CPU sits on the data path — Burstable QoS + CFS throttling under node
-        # pressure would degrade network throughput and silently taint published numbers.
+        # proxy-thread CPU sits on the network data path. What Guaranteed buys here is EXCLUSIVE
+        # CORE PINNING — and only on nodes whose kubelet runs cpuManagerPolicy: static (README
+        # Prerequisites). It does NOT exempt the pod from CFS throttling: cpu: "90" is still a
+        # limit and the proxy threads throttle there regardless of QoS class.
         resources:
           limits:
             nvidia.com/gpu: "8"
@@ -215,7 +217,7 @@ spec:
         securityContext:
           privileged: true                   # gdrdrv device-cgroup (see header)
           capabilities:
-            add: [IPC_LOCK]                  # RDMA memory pinning
+            add: [IPC_LOCK]                  # inert under privileged: true (all caps already granted); kept to record what RDMA memory pinning needs if privileged is later swapped for a gdrdrv device plugin
         ports:
         - { containerPort: 8000,  name: http }
         - { containerPort: 29500, name: dp-rpc }

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/benchmark.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/benchmark.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+# Concurrency sweep against a live serve. Writes fresh benchmarks/raw/<ts>/; exits non-zero on any failure.
+# The pass/fail authority is benchmark_probe.py's exit code (0 only if EVERY request at
+# EVERY level succeeded) — no separate grep gate that could disagree with it.
+set -euo pipefail
+LEADER_IP="${1:?usage: benchmark.sh <leader-ip>}"
+# OUT_ROOT: benchmarks/raw in the repo checkout; inside the pod set OUT_ROOT=/work/benchmarks
+OUT_DIR="${OUT_ROOT:-benchmarks/raw}/$(date -u +%Y%m%dT%H%M%SZ)"; mkdir -p "$OUT_DIR"
+rc=0
+python3 "$(dirname "$0")/benchmark_probe.py" --url "http://${LEADER_IP}:8000/v1/chat/completions" \
+  --out "${OUT_DIR}/sweep.jsonl" | tee "${OUT_DIR}/sweep.txt" || rc=$?
+[ "$rc" -eq 0 ] || { echo "FAIL: probe reported failed requests (rc=$rc) — not a valid run"; exit "$rc"; }
+echo "results in ${OUT_DIR}"

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/benchmark.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/benchmark.sh
@@ -5,8 +5,9 @@
 # EVERY level succeeded) — no separate grep gate that could disagree with it.
 set -euo pipefail
 LEADER_IP="${1:?usage: benchmark.sh <leader-ip>}"
-# OUT_ROOT: benchmarks/raw in the repo checkout; inside the pod set OUT_ROOT=/work/benchmarks
-OUT_DIR="${OUT_ROOT:-benchmarks/raw}/$(date -u +%Y%m%dT%H%M%SZ)"; mkdir -p "$OUT_DIR"
+# OUT_ROOT default is $0-relative (same resolution as the probe path below), so running from the
+# repo root cannot scatter an untracked raw/ tree there; inside the pod set OUT_ROOT=/work/benchmarks
+OUT_DIR="${OUT_ROOT:-$(dirname "$0")/../benchmarks/raw}/$(date -u +%Y%m%dT%H%M%SZ)"; mkdir -p "$OUT_DIR"
 rc=0
 python3 "$(dirname "$0")/benchmark_probe.py" --url "http://${LEADER_IP}:8000/v1/chat/completions" \
   --out "${OUT_DIR}/sweep.jsonl" | tee "${OUT_DIR}/sweep.txt" || rc=$?

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/benchmark_probe.py
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/benchmark_probe.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+# Throughput + latency-vs-concurrency probe for the live vLLM DP/EP serve.
+# Stdlib only (urllib + concurrent.futures) so it runs in the pod with no pip.
+# Methodology (fail-loud, distribution-honest):
+#   - each level fires requests-per-level = conc * NREQ_MULT requests (default 5x) at a
+#     fixed concurrency, so percentiles describe a distribution, not a single shot
+#   - only SUCCESSFUL requests enter the latency percentiles and the token numerator;
+#     failures are counted separately and fail the run (a partially-dead serve must not
+#     report a *better* p50 because refused connections return fast)
+#   - "ignore_eos": true pins every request to exactly max_tokens generated tokens, so
+#     the tok/s denominator is fixed by construction rather than model/prompt-dependent
+#   - each request carries a unique prompt PREFIX (the index goes first), so vLLM's
+#     prefix cache cannot serve request N's prefill from request 1's
+#   - a missing usage block in a 200 response is a FAILURE (code "200-no-usage"), not a
+#     zero-token success that silently deflates throughput
+#   - exit 0 only if EVERY request at EVERY level succeeded
+import argparse, json, os, time, urllib.request, urllib.error, sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+def positive_int(s):
+    # reject <1: a mult of 0 fires zero requests per level and the run exits 0 with empty
+    # tables, quietly defeating the fail-loud contract. argparse reports the message below.
+    v = int(s)
+    if v < 1:
+        raise argparse.ArgumentTypeError(f"must be >= 1 (got {v}); 0 would fire no requests and pass vacuously")
+    return v
+
+# Defaults keep the probe runnable standalone inside the pod (127.0.0.1 loopback);
+# recipe/benchmark.sh overrides --url (leader IP) and --out (raw JSONL path).
+URL = "http://127.0.0.1:8000/v1/chat/completions"
+MODEL = os.environ.get("SERVE_MODEL", "Qwen/Qwen3-30B-A3B-FP8")
+MAX_TOKENS = 128
+PROMPT = "Explain expert parallelism in mixture-of-experts models in two sentences."
+CONCURRENCIES = [1, 8, 16, 32, 64]
+NREQ_MULT = 5  # requests per level = conc * this (>=5x so p50/p90 are distributions)
+
+def one_request(url, idx):
+    body = json.dumps({
+        "model": MODEL,
+        # unique prefix per request (index FIRST) so the prefix cache cannot make
+        # prefill free for requests 2..N — see benchmarks/README methodology notes
+        "messages": [{"role": "user", "content": f"[request {idx}] {PROMPT}"}],
+        "max_tokens": MAX_TOKENS,
+        "ignore_eos": True,   # pin generated tokens == max_tokens (fixed denominator)
+        "temperature": 0.0,
+        "stream": False,
+    }).encode()
+    req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=300) as r:
+            status = r.status   # the ACTUAL code; a 2xx that isn't 200 must not be recorded as 200
+            d = json.loads(r.read())
+        dt = time.time() - t0
+        usage = d.get("usage")
+        if not usage or "completion_tokens" not in usage:
+            # a 200 without usage is a malformed success — surface it, don't count 0 tokens
+            return (False, dt, 0, "200-no-usage")
+        ct = usage["completion_tokens"]
+        # ignore_eos:true makes the contract EXACTLY max_tokens generated tokens — enforce the
+        # fixed denominator rather than assume it (same fail-loud treatment as 200-no-usage).
+        if ct != MAX_TOKENS:
+            return (False, dt, ct, f"{status}-tok{ct}!={MAX_TOKENS}")
+        return (True, dt, ct, status)
+    except urllib.error.HTTPError as e:
+        return (False, time.time() - t0, 0, e.code)
+    except Exception as e:
+        return (False, time.time() - t0, 0, str(e)[:40])
+
+def pct(xs, p):
+    if not xs:
+        return 0.0
+    xs = sorted(xs)
+    k = (len(xs) - 1) * p / 100.0
+    f = int(k)
+    return xs[f] if f + 1 >= len(xs) else xs[f] + (xs[f + 1] - xs[f]) * (k - f)
+
+def sweep(conc, url, nreq_mult):
+    n = conc * nreq_mult
+    t0 = time.time()
+    lat, toks, ok, codes = [], [], 0, {}
+    with ThreadPoolExecutor(max_workers=conc) as ex:
+        # prompt idx must be unique ACROSS levels, not just within one: range(n) restarts at
+        # 0 each level, so conc=16's first 8 prompts would be byte-identical to conc=8's and
+        # get served from the prefix cache — biasing later (higher-conc) levels favourably.
+        # Prefixing with `conc` makes every prompt run-wide-unique (concurrency is unchanged).
+        futs = [ex.submit(one_request, url, f"{conc}-{i}") for i in range(n)]
+        for fu in as_completed(futs):
+            success, dt, ct, code = fu.result()
+            if success:
+                ok += 1
+                lat.append(dt); toks.append(ct)   # successes only (T6): failures must
+                # not deflate percentiles or ride in the throughput denominator
+            codes[str(code)] = codes.get(str(code), 0) + 1
+    wall = time.time() - t0
+    total_tok = sum(toks)
+    return {
+        "conc": conc, "n": n, "ok": ok, "wall_s": round(wall, 2),
+        "total_out_tok": total_tok,
+        "agg_tok_s": round(total_tok / wall, 1) if wall > 0 else 0,
+        "lat_p50_s": round(pct(lat, 50), 2), "lat_p90_s": round(pct(lat, 90), 2),
+        "lat_p99_s": round(pct(lat, 99), 2), "lat_max_s": round(max(lat), 2) if lat else 0,
+        "codes": codes,
+    }
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description="vLLM DeepEP-V2 live-serve throughput/latency probe")
+    ap.add_argument("--url", default=URL, help="chat-completions endpoint (default: 127.0.0.1 loopback)")
+    ap.add_argument("--out", default=None, help="write one JSON object per concurrency level to this path (JSONL)")
+    ap.add_argument("--requests-per-level-mult", type=positive_int, default=NREQ_MULT,
+                    help=f"requests per level = concurrency x this, must be >= 1 (default {NREQ_MULT})")
+    args = ap.parse_args()
+
+    print("=== vLLM DeepEP-V2 live-serve throughput probe ===")
+    print(f"url={args.url} model={MODEL} max_tokens={MAX_TOKENS} (ignore_eos) "
+          f"requests/level={args.requests_per_level_mult}x concurrency")
+    print(f"{'conc':>5} {'n':>5} {'ok':>5} {'wall_s':>7} {'out_tok':>8} {'agg_tok/s':>10} {'p50_s':>7} {'p90_s':>7} {'p99_s':>7} codes")
+    rows = []
+    out_fh = open(args.out, "w") if args.out else None
+    try:
+        for c in CONCURRENCIES:
+            r = sweep(c, args.url, args.requests_per_level_mult)
+            rows.append(r)
+            print(f"{r['conc']:>5} {r['n']:>5} {r['ok']:>5} {r['wall_s']:>7} {r['total_out_tok']:>8} "
+                  f"{r['agg_tok_s']:>10} {r['lat_p50_s']:>7} {r['lat_p90_s']:>7} {r['lat_p99_s']:>7} {r['codes']}")
+            if out_fh:
+                out_fh.write(json.dumps(r) + "\n"); out_fh.flush()
+    finally:
+        if out_fh:
+            out_fh.close()
+    print("JSON_ROWS=" + json.dumps(rows))
+    # fail-loud contract: EVERY request at EVERY level must have succeeded — one dead
+    # backend at one level is a failed run, not a footnote (matches benchmark.sh's gate)
+    sys.exit(0 if all(rw["ok"] == rw["n"] for rw in rows) else 1)

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/benchmark_probe.py
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/benchmark_probe.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
-# Throughput + latency-vs-concurrency probe for the live vLLM DP/EP serve.
+# Throughput + latency-vs-concurrency probe for the live DP/EP serve — vLLM or this sample's
+# Dynamo front; either way the target is the OpenAI-compatible /v1/chat/completions endpoint.
+# (benchmarks/README's tables were measured on the sibling vLLM image with an EARLIER revision
+# of this probe — a run of this one measures a different population; see that README.)
 # Stdlib only (urllib + concurrent.futures) so it runs in the pod with no pip.
 # Methodology (fail-loud, distribution-honest):
 #   - each level fires requests-per-level = conc * NREQ_MULT requests (default 5x) at a
@@ -105,14 +108,14 @@ def sweep(conc, url, nreq_mult):
     }
 
 if __name__ == "__main__":
-    ap = argparse.ArgumentParser(description="vLLM DeepEP-V2 live-serve throughput/latency probe")
+    ap = argparse.ArgumentParser(description="DeepEP-V2 live-serve throughput/latency probe (Dynamo/vLLM OpenAI endpoint)")
     ap.add_argument("--url", default=URL, help="chat-completions endpoint (default: 127.0.0.1 loopback)")
     ap.add_argument("--out", default=None, help="write one JSON object per concurrency level to this path (JSONL)")
     ap.add_argument("--requests-per-level-mult", type=positive_int, default=NREQ_MULT,
                     help=f"requests per level = concurrency x this, must be >= 1 (default {NREQ_MULT})")
     args = ap.parse_args()
 
-    print("=== vLLM DeepEP-V2 live-serve throughput probe ===")
+    print("=== DeepEP-V2 live-serve throughput probe (Dynamo/vLLM OpenAI endpoint) ===")
     print(f"url={args.url} model={MODEL} max_tokens={MAX_TOKENS} (ignore_eos) "
           f"requests/level={args.requests_per_level_mult}x concurrency")
     print(f"{'conc':>5} {'n':>5} {'ok':>5} {'wall_s':>7} {'out_tok':>8} {'agg_tok/s':>10} {'p50_s':>7} {'p90_s':>7} {'p99_s':>7} codes")

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/benchmark_probe.py
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/benchmark_probe.py
@@ -17,6 +17,10 @@
 #     prefix cache cannot serve request N's prefill from request 1's
 #   - a missing usage block in a 200 response is a FAILURE (code "200-no-usage"), not a
 #     zero-token success that silently deflates throughput
+#   - a level with ANY failure reports its codes and fails the run, but emits NO rate or
+#     percentiles (agg_tok_s would divide a success-only token count by an all-request wall)
+#   - p99 is emitted only when a level has >= 100 successful samples; below that the
+#     interpolation just returns ~the max, which is not a distribution statement
 #   - exit 0 only if EVERY request at EVERY level succeeded
 import argparse, json, os, time, urllib.request, urllib.error, sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -50,12 +54,12 @@ def one_request(url, idx):
         "stream": False,
     }).encode()
     req = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
-    t0 = time.time()
+    t0 = time.monotonic()   # monotonic: a wall-clock (NTP) step during a ~27 s interval must not skew latency
     try:
         with urllib.request.urlopen(req, timeout=300) as r:
             status = r.status   # the ACTUAL code; a 2xx that isn't 200 must not be recorded as 200
             d = json.loads(r.read())
-        dt = time.time() - t0
+        dt = time.monotonic() - t0
         usage = d.get("usage")
         if not usage or "completion_tokens" not in usage:
             # a 200 without usage is a malformed success — surface it, don't count 0 tokens
@@ -67,9 +71,9 @@ def one_request(url, idx):
             return (False, dt, ct, f"{status}-tok{ct}!={MAX_TOKENS}")
         return (True, dt, ct, status)
     except urllib.error.HTTPError as e:
-        return (False, time.time() - t0, 0, e.code)
+        return (False, time.monotonic() - t0, 0, e.code)
     except Exception as e:
-        return (False, time.time() - t0, 0, str(e)[:40])
+        return (False, time.monotonic() - t0, 0, str(e)[:40])
 
 def pct(xs, p):
     if not xs:
@@ -81,7 +85,7 @@ def pct(xs, p):
 
 def sweep(conc, url, nreq_mult):
     n = conc * nreq_mult
-    t0 = time.time()
+    t0 = time.monotonic()
     lat, toks, ok, codes = [], [], 0, {}
     with ThreadPoolExecutor(max_workers=conc) as ex:
         # prompt idx must be unique ACROSS levels, not just within one: range(n) restarts at
@@ -96,14 +100,22 @@ def sweep(conc, url, nreq_mult):
                 lat.append(dt); toks.append(ct)   # successes only (T6): failures must
                 # not deflate percentiles or ride in the throughput denominator
             codes[str(code)] = codes.get(str(code), 0) + 1
-    wall = time.time() - t0
+    wall = time.monotonic() - t0
     total_tok = sum(toks)
+    # rate + percentiles only for a fully-successful level: with ok != n, agg_tok_s divides a
+    # success-only numerator by an all-request wall clock, and fast-returning refusals would ride
+    # in the latency stats — the run already fails below; do not format a measurement row too.
+    complete = (n > 0 and ok == n)
     return {
         "conc": conc, "n": n, "ok": ok, "wall_s": round(wall, 2),
         "total_out_tok": total_tok,
-        "agg_tok_s": round(total_tok / wall, 1) if wall > 0 else 0,
-        "lat_p50_s": round(pct(lat, 50), 2), "lat_p90_s": round(pct(lat, 90), 2),
-        "lat_p99_s": round(pct(lat, 99), 2), "lat_max_s": round(max(lat), 2) if lat else 0,
+        "agg_tok_s": round(total_tok / wall, 1) if complete and wall > 0 else None,
+        "lat_p50_s": round(pct(lat, 50), 2) if complete else None,
+        "lat_p90_s": round(pct(lat, 90), 2) if complete else None,
+        # p99 below ~100 samples interpolates between the two largest values (at n=5 it IS the
+        # max) — that is not a distribution statement, so it is omitted rather than mislabeled
+        "lat_p99_s": round(pct(lat, 99), 2) if complete and len(lat) >= 100 else None,
+        "lat_max_s": round(max(lat), 2) if lat else 0,
         "codes": codes,
     }
 
@@ -125,8 +137,9 @@ if __name__ == "__main__":
         for c in CONCURRENCIES:
             r = sweep(c, args.url, args.requests_per_level_mult)
             rows.append(r)
+            fmt = lambda v: "-" if v is None else v   # None = withheld (failed level / p99 under 100 samples)
             print(f"{r['conc']:>5} {r['n']:>5} {r['ok']:>5} {r['wall_s']:>7} {r['total_out_tok']:>8} "
-                  f"{r['agg_tok_s']:>10} {r['lat_p50_s']:>7} {r['lat_p90_s']:>7} {r['lat_p99_s']:>7} {r['codes']}")
+                  f"{fmt(r['agg_tok_s']):>10} {fmt(r['lat_p50_s']):>7} {fmt(r['lat_p90_s']):>7} {fmt(r['lat_p99_s']):>7} {r['codes']}")
             if out_fh:
                 out_fh.write(json.dumps(r) + "\n"); out_fh.flush()
     finally:

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/build_deepep.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/build_deepep.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+# build_deepep.sh — build DeepEP-V2 _C.so IN-POD (needs a live CUDA context, so it
+# cannot run in the Docker build sandbox). Run ONCE on first pod boot.
+#
+# The DeepEP source + PR612 + multi-comm overlay are already staged at /opt/DeepEP by
+# the Dockerfile. This compiles the CUDA extension and pip-installs it editable so
+# `import deep_ep` resolves to /opt/DeepEP with ElasticBuffer present.
+#
+# CUDA toolchain: the image's torch is cu130, so we build with the cu13 nvcc toolchain
+# (pip nvidia-cuda-nvcc-cu13) to match the torch ABI. The path is AUTO-DISCOVERED (the
+# python minor version differs across base images, so we never hardcode python3.NN).
+# If the cu13 nvcc cannot be obtained, we fall back to the base /usr/local/cuda nvcc.
+#
+# Verify after: python3 -c "import deep_ep; print(hasattr(deep_ep,'ElasticBuffer'))" -> True
+set -euo pipefail
+
+DEEPEP_DIR="${DEEPEP_DIR:-/opt/DeepEP}"
+test -d "$DEEPEP_DIR" || { echo "FATAL: $DEEPEP_DIR missing (Dockerfile DeepEP layer should have cloned it)"; exit 2; }
+
+# ---- discover the python site-packages dir (version-agnostic) ---------------
+SITE="$(python3 -c 'import site;print(site.getsitepackages()[0])')"
+echo "=== site-packages: $SITE ==="
+
+# ---- FAST PATH: if the BASE /usr/local/cuda is already CUDA 13.x, use it directly -----------
+# A CUDA-13 NGC base (nvcr.io/nvidia/cuda:13.0.x) ships a COHERENT toolkit (nvcc + cudart headers +
+# cccl all on the same minor) that matches torch cu130. Using it avoids the entire fragile cu13-pip
+# reconstruction (the nvcc/crt/nvvm/runtime/cccl/cublas version-web that fails on a cu12.9 base).
+CU13=""
+FAST_BASE=""
+if [ -x /usr/local/cuda/bin/nvcc ] && /usr/local/cuda/bin/nvcc --version 2>/dev/null | grep -q "release 13"; then
+  echo "=== FAST PATH: base /usr/local/cuda is CUDA 13.x ($(/usr/local/cuda/bin/nvcc --version|grep -i release)) — using it, no cu13 pip reconstruction ==="
+  CU13=/usr/local/cuda
+  FAST_BASE=1   # base is coherent CUDA-13: do NOT let find_cu13 override it with a stale pip cu13
+fi
+
+# ---- otherwise (cu12.x base): locate or pip-reconstruct a cu13 nvcc toolchain ---------------
+find_cu13() {
+  for d in "$SITE"/nvidia/cu13 "$SITE"/nvidia/cuda_nvcc /usr/local/lib/python3.*/dist-packages/nvidia/cu13; do
+    [ -x "$d/bin/nvcc" ] && { echo "$d"; return 0; }
+  done
+  return 1
+}
+[ -z "$CU13" ] && [ -z "$FAST_BASE" ] && CU13="$(find_cu13 || true)"
+if [ -z "$FAST_BASE" ] && { [ -z "$CU13" ] || [ ! -x "$CU13/bin/nvcc" ]; }; then
+  # The cu13 nvcc ships as the UNSUFFIXED `nvidia-cuda-nvcc` (version 13.x); the `-cu13`
+  # suffix does not exist on PyPI (it errors as a redirect stub). 13.0.88 matches torch cu130.
+  # It installs nvcc + crt + nvvm under nvidia/cu13/. Match the torch CUDA minor (13.0).
+  echo "=== installing cu13 nvcc toolchain (nvcc + crt + nvvm + cccl, ALL pinned 13.0.x) ==="
+  # PIN every cu13 component to the SAME version: nvidia-cuda-nvcc pulls crt+nvvm as deps, but
+  # unpinned they resolve to 13.3.x while nvcc is 13.0.88 -> cicc emits PTX 9.3 that the 13.0
+  # ptxas rejects ("Unsupported .version 9.3; current is 9.0"). Pinning crt+nvvm to 13.0.88
+  # keeps cicc and ptxas on the same PTX ISA. cccl 13.0.50 provides nv/target (no 13.0.88 cccl).
+  # --force-reinstall so a pre-existing HIGHER crt/nvvm (e.g. 13.3.x pulled as an nvcc dep on an
+  # earlier run) is actually DOWNGRADED to 13.0.88; pip won't downgrade an already-satisfied req otherwise.
+  # ALL five cu13 components must be the SAME CUDA minor (13.0): nvcc + crt + nvvm + RUNTIME + cccl.
+  # The runtime is the subtle one — its cuda_runtime_api.h sets CUDART_VERSION, and CCCL's
+  # cuda_toolkit.h hard-errors ("CUDA compiler and CUDA toolkit headers are incompatible") unless
+  # CUDART_VERSION matches the nvcc compiler version. An unpinned runtime resolves to 13.3 while nvcc
+  # is 13.0.88 -> the error. Pin runtime==13.0.88 too. (cccl 13.0.85 is the nearest 13.0.x cccl.)
+  # NOTE: no --break-system-packages — the image ships pip 22.0.2 and that flag arrived
+  # in pip 23.0; passing it makes pip exit 2 ("no such option") BEFORE installing, and
+  # would then mask a wrong-ABI fallback build. (Ubuntu 22.04 python3.10 is not
+  # PEP-668-managed, so the flag is unnecessary here anyway.)
+  # FAIL LOUD, do NOT `|| true`: a masked pip failure here (no PyPI egress, resolver conflict,
+  # no disk) is indistinguishable from success — find_cu13 then yields empty and the build
+  # silently falls back to the base /usr/local/cuda, i.e. the wrong-ABI build this block exists
+  # to prevent. A clear "cu13 toolchain unavailable" beats an ABI error three steps later.
+  # (pipefail is set, so a pip failure through the tail pipe aborts here.)
+  pip install --no-cache-dir --force-reinstall \
+      "nvidia-cuda-nvcc==13.0.88" "nvidia-cuda-crt==13.0.88" "nvidia-nvvm==13.0.88" \
+      "nvidia-cuda-runtime==13.0.88" "nvidia-cuda-cccl==13.0.85" 2>&1 | tail -4
+  CU13="$(find_cu13 || true)"
+  [ -n "$CU13" ] && [ -x "$CU13/bin/nvcc" ] || { echo "FATAL: cu13 toolchain install succeeded but no nvcc found under $SITE/nvidia/cu13 — cannot build the cu130-ABI DeepEP extension (base /usr/local/cuda would be the wrong ABI)"; exit 4; }
+fi
+
+# ---- choose the build toolchain ---------------------------------------------
+if [ -n "$CU13" ] && [ -x "$CU13/bin/nvcc" ]; then
+  CUDA_HOME_BUILD="$CU13"
+  echo "=== build CUDA_HOME = cu13 toolchain: $CUDA_HOME_BUILD ($($CU13/bin/nvcc --version | grep -i release)) ==="
+elif [ -x /usr/local/cuda/bin/nvcc ]; then
+  CUDA_HOME_BUILD=/usr/local/cuda
+  echo "=== WARN: cu13 nvcc unavailable; falling back to base nvcc: $($CUDA_HOME_BUILD/bin/nvcc --version | grep -i release) ==="
+  echo "=== (if the _C.so import later fails with an ABI error, the cu13 toolchain is required) ==="
+else
+  echo "FATAL: no nvcc found (neither cu13 pip toolchain nor /usr/local/cuda)"; exit 3
+fi
+
+# DeepEP's extension device-links (dlink=True), which REQUIRES ninja (distutils backend
+# cannot device-link). The Dockerfile pre-installs ninja at build time (a first-boot pip
+# install assumes PyPI egress from the pod — wrong on private-subnet/air-gapped clusters);
+# this guard remains only for non-canonical bases.
+python3 -c "import ninja" 2>/dev/null || { echo "=== installing ninja (required for dlink CUDA ext; MISSING from image — non-canonical base?) ==="; pip install --no-cache-dir ninja 2>&1 | tail -2; }
+
+cd "$DEEPEP_DIR"
+rm -rf build/temp.* deep_ep/_C*.so 2>/dev/null || true
+
+# ---- link-time library paths + unversioned .so symlinks ----------------------
+# DeepEP's final link wants `-l:libnvshmem_host.so` and `-lcudart`. The wheels ship
+# versioned libs (libnvshmem_host.so.3) without the unversioned linker name, and the
+# cu13 runtime ships only a static libcudart, so we point at the base dynamic libcudart.
+# nvshmem lib dir: prefer the import, but FALL BACK to the known site-packages path — on some bases
+# `import nvidia.nvshmem` raises (namespace-package __file__ is None) even though the lib is present.
+# nvidia.nvshmem is a NAMESPACE package (no __init__.py) => its __file__ is None on modern
+# wheels, which makes `os.path.dirname(nvidia.nvshmem.__file__)` raise and (with `|| true`)
+# silently yield an empty NVSHMEM_LIB -> the unversioned symlink below is never created ->
+# the final link dies with `cannot find -l:libnvshmem_host.so`. Resolve via find_spec's
+# submodule_search_locations (works for namespace packages), then fall back to the glob.
+NVSHMEM_LIB="$(python3 -c 'import importlib.util,os
+s=importlib.util.find_spec("nvidia.nvshmem")
+p=(s.submodule_search_locations[0] if s and s.submodule_search_locations else None)
+print(os.path.join(p,"lib") if p else "")' 2>/dev/null || true)"
+# `ls -d A B` with only A present prints A but exits 2; pipefail carries that through | head,
+# and since this assignment is the last command in the `||` list, `set -e` would abort the
+# very fallback this line exists to provide. `|| true` keeps the recovered path and the script.
+[ -d "$NVSHMEM_LIB" ] || NVSHMEM_LIB="$(ls -d "$SITE"/nvidia/nvshmem/lib /usr/local/lib/python3.*/dist-packages/nvidia/nvshmem/lib 2>/dev/null | head -1 || true)"
+if [ -n "$NVSHMEM_LIB" ] && [ -d "$NVSHMEM_LIB" ]; then
+  [ -e "$NVSHMEM_LIB/libnvshmem_host.so" ] || ln -sf "$(ls "$NVSHMEM_LIB"/libnvshmem_host.so.* | head -1)" "$NVSHMEM_LIB/libnvshmem_host.so" 2>/dev/null || true
+fi
+CUDART_DIR="/usr/local/cuda/lib64"   # dynamic libcudart.so lives here (base runtime)
+
+echo "=== nvcc build_ext (TORCH_CUDA_ARCH_LIST=${DEEPEP_ARCH_LIST:-9.0}: 9.0=H100/H200, 10.0=B200) ==="
+CUDA_HOME="$CUDA_HOME_BUILD" \
+PATH="$CUDA_HOME_BUILD/bin:$PATH" \
+LIBRARY_PATH="${NVSHMEM_LIB:-}:${CUDART_DIR}:${LIBRARY_PATH:-}" \
+LD_LIBRARY_PATH="${NVSHMEM_LIB:-}:${CUDART_DIR}:${LD_LIBRARY_PATH:-}" \
+TORCH_CUDA_ARCH_LIST="${DEEPEP_ARCH_LIST:-9.0}" \
+MAX_JOBS="$(nproc)" \
+python3 setup.py build_ext --inplace 2>&1 | tee /tmp/deepep-build.log | tail -30   # full log at /tmp/deepep-build.log for failed-build diagnostics
+
+echo "=== editable install so 'import deep_ep' resolves here (best-effort) ==="
+# The _C.so is now in-tree, so `import deep_ep` from /opt/DeepEP works directly. The pip
+# editable install can fail (pip build isolation re-triggers a sandboxed build) but is
+# NOT required — fall back to a .pth that puts /opt/DeepEP on sys.path so every
+# interpreter resolves it.
+pip install --no-cache-dir -e . 2>&1 | tail -3 || {
+  echo "(editable install failed — using a .pth fallback instead)"
+  SITE="$(python3 -c 'import site;print(site.getsitepackages()[0])')"
+  echo "$DEEPEP_DIR" > "$SITE/deep_ep_src.pth"
+}
+
+echo "=== verify ElasticBuffer present (EFA-viable; legacy Buffer is NVSHMEM/IBGDA = dead on EFA) ==="
+# NVSHMEM host lib must be on LD_LIBRARY_PATH at import (the _C.so links it). Reuse the
+# find_spec resolution (namespace-package safe) rather than the None-yielding __file__ form.
+NVSHMEM_LIB="$(python3 -c 'import importlib.util,os
+s=importlib.util.find_spec("nvidia.nvshmem")
+p=(s.submodule_search_locations[0] if s and s.submodule_search_locations else None)
+print(os.path.join(p,"lib") if p else "")' 2>/dev/null || true)"
+[ -d "$NVSHMEM_LIB" ] || NVSHMEM_LIB="$(ls -d /usr/local/lib/python3.*/dist-packages/nvidia/nvshmem/lib 2>/dev/null | head -1 || true)"   # same ls-exit-2-under-pipefail guard as above
+LD_LIBRARY_PATH="${NVSHMEM_LIB:-}:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}" \
+  python3 -c "import deep_ep; print('deep_ep:', deep_ep.__file__); assert hasattr(deep_ep,'ElasticBuffer'), 'ElasticBuffer MISSING'; print('ElasticBuffer: OK')"
+echo "=== build_deepep DONE (remember: set LD_LIBRARY_PATH to include $NVSHMEM_LIB at serve time) ==="

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/build_deepep.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/build_deepep.sh
@@ -3,14 +3,13 @@
 # build_deepep.sh — build DeepEP-V2 _C.so IN-POD (needs a live CUDA context, so it
 # cannot run in the Docker build sandbox). Run ONCE on first pod boot.
 #
-# The DeepEP source + PR612 + multi-comm overlay are already staged at /opt/DeepEP by
-# the Dockerfile. This compiles the CUDA extension and pip-installs it editable so
-# `import deep_ep` resolves to /opt/DeepEP with ElasticBuffer present.
+# The DeepEP source (amazon-contributing fork, SHA-pinned) is already staged at /opt/DeepEP
+# by the Dockerfile. This compiles the CUDA extension in-tree and registers /opt/DeepEP on
+# sys.path via a .pth so `import deep_ep` resolves there with ElasticBuffer present.
 #
-# CUDA toolchain: the image's torch is cu130, so we build with the cu13 nvcc toolchain
-# (pip nvidia-cuda-nvcc-cu13) to match the torch ABI. The path is AUTO-DISCOVERED (the
-# python minor version differs across base images, so we never hardcode python3.NN).
-# If the cu13 nvcc cannot be obtained, we fall back to the base /usr/local/cuda nvcc.
+# CUDA toolchain: the image's torch is cu130 and the base is nvcr.io/nvidia/cuda:13.0.x-devel,
+# so the base /usr/local/cuda IS the matching toolchain — asserted below. Any other base would
+# be a wrong-ABI build surfacing later as an import error, so the script stops instead.
 #
 # Verify after: python3 -c "import deep_ep; print(hasattr(deep_ep,'ElasticBuffer'))" -> True
 set -euo pipefail
@@ -22,90 +21,34 @@ test -d "$DEEPEP_DIR" || { echo "FATAL: $DEEPEP_DIR missing (Dockerfile DeepEP l
 SITE="$(python3 -c 'import site;print(site.getsitepackages()[0])')"
 echo "=== site-packages: $SITE ==="
 
-# ---- FAST PATH: if the BASE /usr/local/cuda is already CUDA 13.x, use it directly -----------
-# A CUDA-13 NGC base (nvcr.io/nvidia/cuda:13.0.x) ships a COHERENT toolkit (nvcc + cudart headers +
-# cccl all on the same minor) that matches torch cu130. Using it avoids the entire fragile cu13-pip
-# reconstruction (the nvcc/crt/nvvm/runtime/cccl/cublas version-web that fails on a cu12.9 base).
-CU13=""
-FAST_BASE=""
-if [ -x /usr/local/cuda/bin/nvcc ] && /usr/local/cuda/bin/nvcc --version 2>/dev/null | grep -q "release 13"; then
-  echo "=== FAST PATH: base /usr/local/cuda is CUDA 13.x ($(/usr/local/cuda/bin/nvcc --version|grep -i release)) — using it, no cu13 pip reconstruction ==="
-  CU13=/usr/local/cuda
-  FAST_BASE=1   # base is coherent CUDA-13: do NOT let find_cu13 override it with a stale pip cu13
-fi
-
-# ---- otherwise (cu12.x base): locate or pip-reconstruct a cu13 nvcc toolchain ---------------
-find_cu13() {
-  for d in "$SITE"/nvidia/cu13 "$SITE"/nvidia/cuda_nvcc /usr/local/lib/python3.*/dist-packages/nvidia/cu13; do
-    [ -x "$d/bin/nvcc" ] && { echo "$d"; return 0; }
-  done
-  return 1
-}
-[ -z "$CU13" ] && [ -z "$FAST_BASE" ] && CU13="$(find_cu13 || true)"
-if [ -z "$FAST_BASE" ] && { [ -z "$CU13" ] || [ ! -x "$CU13/bin/nvcc" ]; }; then
-  # The cu13 nvcc ships as the UNSUFFIXED `nvidia-cuda-nvcc` (version 13.x); the `-cu13`
-  # suffix does not exist on PyPI (it errors as a redirect stub). 13.0.88 matches torch cu130.
-  # It installs nvcc + crt + nvvm under nvidia/cu13/. Match the torch CUDA minor (13.0).
-  echo "=== installing cu13 nvcc toolchain (nvcc + crt + nvvm + cccl, ALL pinned 13.0.x) ==="
-  # PIN every cu13 component to the SAME version: nvidia-cuda-nvcc pulls crt+nvvm as deps, but
-  # unpinned they resolve to 13.3.x while nvcc is 13.0.88 -> cicc emits PTX 9.3 that the 13.0
-  # ptxas rejects ("Unsupported .version 9.3; current is 9.0"). Pinning crt+nvvm to 13.0.88
-  # keeps cicc and ptxas on the same PTX ISA. cccl 13.0.50 provides nv/target (no 13.0.88 cccl).
-  # --force-reinstall so a pre-existing HIGHER crt/nvvm (e.g. 13.3.x pulled as an nvcc dep on an
-  # earlier run) is actually DOWNGRADED to 13.0.88; pip won't downgrade an already-satisfied req otherwise.
-  # ALL five cu13 components must be the SAME CUDA minor (13.0): nvcc + crt + nvvm + RUNTIME + cccl.
-  # The runtime is the subtle one — its cuda_runtime_api.h sets CUDART_VERSION, and CCCL's
-  # cuda_toolkit.h hard-errors ("CUDA compiler and CUDA toolkit headers are incompatible") unless
-  # CUDART_VERSION matches the nvcc compiler version. An unpinned runtime resolves to 13.3 while nvcc
-  # is 13.0.88 -> the error. Pin runtime==13.0.88 too. (cccl 13.0.85 is the nearest 13.0.x cccl.)
-  # NOTE: no --break-system-packages — the image ships pip 22.0.2 and that flag arrived
-  # in pip 23.0; passing it makes pip exit 2 ("no such option") BEFORE installing, and
-  # would then mask a wrong-ABI fallback build. (Ubuntu 22.04 python3.10 is not
-  # PEP-668-managed, so the flag is unnecessary here anyway.)
-  # FAIL LOUD, do NOT `|| true`: a masked pip failure here (no PyPI egress, resolver conflict,
-  # no disk) is indistinguishable from success — find_cu13 then yields empty and the build
-  # silently falls back to the base /usr/local/cuda, i.e. the wrong-ABI build this block exists
-  # to prevent. A clear "cu13 toolchain unavailable" beats an ABI error three steps later.
-  # (pipefail is set, so a pip failure through the tail pipe aborts here.)
-  pip install --no-cache-dir --force-reinstall \
-      "nvidia-cuda-nvcc==13.0.88" "nvidia-cuda-crt==13.0.88" "nvidia-nvvm==13.0.88" \
-      "nvidia-cuda-runtime==13.0.88" "nvidia-cuda-cccl==13.0.85" 2>&1 | tail -4
-  CU13="$(find_cu13 || true)"
-  [ -n "$CU13" ] && [ -x "$CU13/bin/nvcc" ] || { echo "FATAL: cu13 toolchain install succeeded but no nvcc found under $SITE/nvidia/cu13 — cannot build the cu130-ABI DeepEP extension (base /usr/local/cuda would be the wrong ABI)"; exit 4; }
-fi
-
-# ---- choose the build toolchain ---------------------------------------------
-if [ -n "$CU13" ] && [ -x "$CU13/bin/nvcc" ]; then
-  CUDA_HOME_BUILD="$CU13"
-  echo "=== build CUDA_HOME = cu13 toolchain: $CUDA_HOME_BUILD ($($CU13/bin/nvcc --version | grep -i release)) ==="
-elif [ -x /usr/local/cuda/bin/nvcc ]; then
-  CUDA_HOME_BUILD=/usr/local/cuda
-  echo "=== WARN: cu13 nvcc unavailable; falling back to base nvcc: $($CUDA_HOME_BUILD/bin/nvcc --version | grep -i release) ==="
-  echo "=== (if the _C.so import later fails with an ABI error, the cu13 toolchain is required) ==="
-else
-  echo "FATAL: no nvcc found (neither cu13 pip toolchain nor /usr/local/cuda)"; exit 3
-fi
+# ---- toolchain: the base /usr/local/cuda MUST be CUDA 13.x (the torch cu130 ABI) -------------
+# The sample owns its base image (FROM nvcr.io/nvidia/cuda:13.0.x-devel, Dockerfile), whose
+# toolkit is coherent (nvcc + cudart headers + cccl on the same minor) and matches torch cu130.
+# Hard-assert that instead of carrying fallbacks: the old cu12->cu13 pip reconstruction and the
+# base-nvcc fallback were unreachable on this base, and the fallback's firing condition was
+# exactly the wrong-ABI build it claimed to prevent. This also keeps first pod boot free of any
+# pip/PyPI dependency (private-subnet/air-gapped clusters).
+{ [ -x /usr/local/cuda/bin/nvcc ] && /usr/local/cuda/bin/nvcc --version 2>/dev/null | grep -q "release 13"; } \
+  || { echo "FATAL: /usr/local/cuda is not a CUDA 13.x toolkit — torch is cu130; build this sample's Dockerfile (FROM nvcr.io/nvidia/cuda:13.0.x-devel), do not swap the base"; exit 3; }
+CUDA_HOME_BUILD=/usr/local/cuda
+echo "=== build CUDA_HOME = $CUDA_HOME_BUILD ($(/usr/local/cuda/bin/nvcc --version | grep -i release)) ==="
 
 # DeepEP's extension device-links (dlink=True), which REQUIRES ninja (distutils backend
-# cannot device-link). The Dockerfile pre-installs ninja at build time (a first-boot pip
-# install assumes PyPI egress from the pod — wrong on private-subnet/air-gapped clusters);
-# this guard remains only for non-canonical bases.
-python3 -c "import ninja" 2>/dev/null || { echo "=== installing ninja (required for dlink CUDA ext; MISSING from image — non-canonical base?) ==="; pip install --no-cache-dir ninja 2>&1 | tail -2; }
+# cannot device-link). The Dockerfile bakes ninja at image-build time: first pod boot must
+# not depend on PyPI egress (private-subnet/air-gapped clusters would fail inside a compile
+# step instead of a clear network error). Missing ninja = non-canonical image; stop.
+python3 -c "import ninja" 2>/dev/null || { echo "FATAL: ninja missing from image (the Dockerfile bakes it — rebuild from this sample's Dockerfile rather than pip-installing at boot)"; exit 3; }
 
 cd "$DEEPEP_DIR"
 rm -rf build/temp.* deep_ep/_C*.so 2>/dev/null || true
 
-# ---- link-time library paths + unversioned .so symlinks ----------------------
-# DeepEP's final link wants `-l:libnvshmem_host.so` and `-lcudart`. The wheels ship
-# versioned libs (libnvshmem_host.so.3) without the unversioned linker name, and the
-# cu13 runtime ships only a static libcudart, so we point at the base dynamic libcudart.
-# nvshmem lib dir: prefer the import, but FALL BACK to the known site-packages path — on some bases
-# `import nvidia.nvshmem` raises (namespace-package __file__ is None) even though the lib is present.
-# nvidia.nvshmem is a NAMESPACE package (no __init__.py) => its __file__ is None on modern
-# wheels, which makes `os.path.dirname(nvidia.nvshmem.__file__)` raise and (with `|| true`)
-# silently yield an empty NVSHMEM_LIB -> the unversioned symlink below is never created ->
-# the final link dies with `cannot find -l:libnvshmem_host.so`. Resolve via find_spec's
-# submodule_search_locations (works for namespace packages), then fall back to the glob.
+# ---- link-time library paths -------------------------------------------------
+# DeepEP's setup.py at the pinned fork head resolves the wheels' VERSIONED sonames itself
+# (_find_versioned_so / get_nvshmem_host_lib_name -> `-l:libnvshmem_host.so.3`), so no
+# unversioned-symlink workaround is needed — the linker only needs the lib DIRECTORIES on
+# LIBRARY_PATH. The dynamic libcudart.so comes from the base toolkit.
+# nvidia.nvshmem is a NAMESPACE package (no __init__.py => __file__ is None on modern wheels),
+# so resolve its lib dir via find_spec's submodule_search_locations, not __file__.
 NVSHMEM_LIB="$(python3 -c 'import importlib.util,os
 s=importlib.util.find_spec("nvidia.nvshmem")
 p=(s.submodule_search_locations[0] if s and s.submodule_search_locations else None)
@@ -114,39 +57,32 @@ print(os.path.join(p,"lib") if p else "")' 2>/dev/null || true)"
 # and since this assignment is the last command in the `||` list, `set -e` would abort the
 # very fallback this line exists to provide. `|| true` keeps the recovered path and the script.
 [ -d "$NVSHMEM_LIB" ] || NVSHMEM_LIB="$(ls -d "$SITE"/nvidia/nvshmem/lib /usr/local/lib/python3.*/dist-packages/nvidia/nvshmem/lib 2>/dev/null | head -1 || true)"
-if [ -n "$NVSHMEM_LIB" ] && [ -d "$NVSHMEM_LIB" ]; then
-  [ -e "$NVSHMEM_LIB/libnvshmem_host.so" ] || ln -sf "$(ls "$NVSHMEM_LIB"/libnvshmem_host.so.* | head -1)" "$NVSHMEM_LIB/libnvshmem_host.so" 2>/dev/null || true
-fi
+# one-line assert of the condition setup.py's soname resolution depends on:
+ls "${NVSHMEM_LIB:-/nonexistent}"/libnvshmem_host.so.* >/dev/null 2>&1 || { echo "FATAL: no libnvshmem_host.so.* under '${NVSHMEM_LIB:-<unresolved>}' — the nvidia-nvshmem-cu13 wheel (Dockerfile Layer 3/5b) is missing or moved"; exit 4; }
 CUDART_DIR="/usr/local/cuda/lib64"   # dynamic libcudart.so lives here (base runtime)
 
 echo "=== nvcc build_ext (TORCH_CUDA_ARCH_LIST=${DEEPEP_ARCH_LIST:-9.0}: 9.0=H100/H200, 10.0=B200) ==="
 CUDA_HOME="$CUDA_HOME_BUILD" \
 PATH="$CUDA_HOME_BUILD/bin:$PATH" \
-LIBRARY_PATH="${NVSHMEM_LIB:-}:${CUDART_DIR}:${LIBRARY_PATH:-}" \
-LD_LIBRARY_PATH="${NVSHMEM_LIB:-}:${CUDART_DIR}:${LD_LIBRARY_PATH:-}" \
+LIBRARY_PATH="${NVSHMEM_LIB:+$NVSHMEM_LIB:}${CUDART_DIR}:${LIBRARY_PATH:-}" \
+LD_LIBRARY_PATH="${NVSHMEM_LIB:+$NVSHMEM_LIB:}${CUDART_DIR}:${LD_LIBRARY_PATH:-}" \
 TORCH_CUDA_ARCH_LIST="${DEEPEP_ARCH_LIST:-9.0}" \
 MAX_JOBS="$(nproc)" \
 python3 setup.py build_ext --inplace 2>&1 | tee /tmp/deepep-build.log | tail -30   # full log at /tmp/deepep-build.log for failed-build diagnostics
 
-echo "=== editable install so 'import deep_ep' resolves here (best-effort) ==="
-# The _C.so is now in-tree, so `import deep_ep` from /opt/DeepEP works directly. The pip
-# editable install can fail (pip build isolation re-triggers a sandboxed build) but is
-# NOT required — fall back to a .pth that puts /opt/DeepEP on sys.path so every
-# interpreter resolves it.
-pip install --no-cache-dir -e . 2>&1 | tail -3 || {
-  echo "(editable install failed — using a .pth fallback instead)"
-  SITE="$(python3 -c 'import site;print(site.getsitepackages()[0])')"
-  echo "$DEEPEP_DIR" > "$SITE/deep_ep_src.pth"
-}
+echo "=== register $DEEPEP_DIR on sys.path via .pth (deterministic; pip -e cannot work here) ==="
+# No `pip install -e .`: DeepEP's pyproject.toml has no [build-system] table, so pip's PEP 517
+# default is an ISOLATED env (setuptools+wheel, system site-packages excluded) in which
+# setup.py's top-level `from torch.utils.cpp_extension import ...` cannot resolve — the attempt
+# fails deterministically on every boot. And if isolation were ever satisfied, the editable
+# build would re-run build_ext WITHOUT the CUDA_HOME/LIBRARY_PATH/TORCH_CUDA_ARCH_LIST prefix
+# above and could overwrite the working _C.so. The .pth — the state every boot ended up in
+# anyway — is written unconditionally instead.
+echo "$DEEPEP_DIR" > "$SITE/deep_ep_src.pth"
 
 echo "=== verify ElasticBuffer present (EFA-viable; legacy Buffer is NVSHMEM/IBGDA = dead on EFA) ==="
-# NVSHMEM host lib must be on LD_LIBRARY_PATH at import (the _C.so links it). Reuse the
-# find_spec resolution (namespace-package safe) rather than the None-yielding __file__ form.
-NVSHMEM_LIB="$(python3 -c 'import importlib.util,os
-s=importlib.util.find_spec("nvidia.nvshmem")
-p=(s.submodule_search_locations[0] if s and s.submodule_search_locations else None)
-print(os.path.join(p,"lib") if p else "")' 2>/dev/null || true)"
-[ -d "$NVSHMEM_LIB" ] || NVSHMEM_LIB="$(ls -d /usr/local/lib/python3.*/dist-packages/nvidia/nvshmem/lib 2>/dev/null | head -1 || true)"   # same ls-exit-2-under-pipefail guard as above
-LD_LIBRARY_PATH="${NVSHMEM_LIB:-}:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}" \
+# NVSHMEM host lib must be on LD_LIBRARY_PATH at import (the _C.so links it) — reuse the
+# resolution above rather than re-deriving it.
+LD_LIBRARY_PATH="${NVSHMEM_LIB:+$NVSHMEM_LIB:}/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}" \
   python3 -c "import deep_ep; print('deep_ep:', deep_ep.__file__); assert hasattr(deep_ep,'ElasticBuffer'), 'ElasticBuffer MISSING'; print('ElasticBuffer: OK')"
 echo "=== build_deepep DONE (remember: set LD_LIBRARY_PATH to include $NVSHMEM_LIB at serve time) ==="

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/run-kernel-test.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/run-kernel-test.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+# run-kernel-test.sh — prove DeepEP-V2 dispatch/combine actually moves bytes over EFA BEFORE the
+# ~ multi-hundred-GB model load. This is the "smoke-test the transport" gate: it runs DeepEP-V2's own
+# elastic EP test (tests/elastic/test_ep.py) across the nodes with the SAME proxy-Gin/EFA env the
+# serve uses, and exits non-zero on failure. Cheap, and the one step that cannot hang for hours.
+#
+#   leader:  run-kernel-test.sh leader <leader-ip>
+#   worker:  run-kernel-test.sh worker <leader-ip> <node-rank>   # node-rank 1,2,3 for the worker nodes
+#
+# Env (shared with serve.sh): NNODES (default 2), GPUS_PER_NODE (default 8).
+set -uo pipefail
+
+ROLE="${1:?usage: run-kernel-test.sh leader|worker <leader-ip> [node-rank]}"
+case "$ROLE" in leader|worker) ;; *) echo "FATAL: unrecognized role '$ROLE' (leader|worker)"; exit 2 ;; esac
+LEADER_IP="${2:?need leader ip}"
+if [ "$ROLE" = "worker" ]; then NODE_RANK_ARG="${3:?worker requires an explicit node-rank (1,2,...)}"; else NODE_RANK_ARG=0; fi
+NNODES="${NNODES:-2}"
+GPUS_PER_NODE="${GPUS_PER_NODE:-8}"
+TEST="/opt/DeepEP/tests/elastic/test_ep.py"
+[ -f "$TEST" ] || { echo "FAIL: $TEST not in image — rebuild from setup_deepep_v2_efa.sh"; exit 3; }
+
+# ---- proxy-Gin + EFA contract, VERBATIM from serve.sh (same transport under test) ----
+export NCCL_GIN_TYPE=2 NCCL_GIN_ENABLE=1 OFI_NCCL_GIN_GDAKI=0 OFI_NCCL_GIN_MAX_REQUESTS=512
+export NCCL_CUMEM_ENABLE=1 NCCL_NVLS_ENABLE=0 NCCL_IGNORE_DISABLED_P2P=1
+export FI_PROVIDER=efa FI_EFA_USE_DEVICE_RDMA=1 FI_EFA_ENABLE_SHM_TRANSFER=0 FI_EFA_FORK_SAFE=1
+export OFI_NCCL_PROTOCOL=RDMA DEEP_EP_BACKEND=nccl
+export NCCL_NET_PLUGIN=/opt/aws-ofi-nccl/lib/libnccl-net-ofi.so
+export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-^lo,docker,veth}   # exclusion, never positive selection: EFA nodes expose efa*/enp* and CNI adds bridges; auto-select can pick a non-routing iface -> rendezvous hang. Repo convention (nccl-tests Dockerfile). Kept identical to serve.sh so this claim ("VERBATIM from serve.sh") stays true.
+export OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1
+export EP_REUSE_NCCL_COMM=0          # DeepEP own-comm (segfault rootcause 2026-08-14)
+export NCCL_DEBUG=${KERNEL_TEST_NCCL_DEBUG:-INFO}   # INFO so the efa-direct banner prints = transport proof
+
+NODE_RANK="$NODE_RANK_ARG"; [ "$ROLE" = "leader" ] && NODE_RANK=0
+echo "===== DeepEP-V2 kernel smoke: role=$ROLE node_rank=$NODE_RANK nnodes=$NNODES gpus/node=$GPUS_PER_NODE leader=$LEADER_IP $(hostname) $(date -u +%FT%TZ) ====="
+
+set -o pipefail
+# ONE torchrun process per node: test_ep.py spawns its own local ranks internally
+# (torch.multiprocessing.spawn with --num-processes, default 8) and DeepEP's init_dist
+# reads WORLD_SIZE as a NODE count (num_nodes = WORLD_SIZE, world = nodes x local_ranks).
+# --nproc-per-node=8 double-fans-out (2 nodes -> 16 procs x 8 spawns = 128 ranks on 16
+# GPUs) and collides MASTER_PORT 29501 with torchrun's own rendezvous -> NCCL "invalid
+# usage" at init_process_group, every time. One proc/node lets the test own the fan-out.
+#
+# --test-first-only --skip-perf-test is what keeps this a SMOKE test (the "cannot hang
+# for hours" claim in the header). The stock test_ep.py sweeps its full correctness+perf
+# matrix (~1600 profiled dispatch/combine cases at DP16); measured here it runs >10 min
+# and trips any sane timeout with rc=124 EVEN WHEN THE TRANSPORT IS PERFECT (verified on
+# 2x p5en 2026-09-04: efa-direct banner + real bytes on all 16 ranks, yet the unbounded
+# form hit the 600s bound). --test-first-only runs ONE case; --skip-perf-test gates ONLY
+# the bench_kineto timing block (test_ep.py:234) — the dispatch()/combine() correctness
+# cycle and its ~30 torch.equal asserts (lines 111-200) STILL run, so bytes still move
+# over EFA and correctness is still verified. Bounded form measured ~90s end-to-end.
+# `timeout` remains as the hard safety bound (a wrong NNODES / a worker that never starts
+# / a stalled NCCL init blocks indefinitely otherwise); 180s is comfortably above the ~90s
+# measured runtime. timeout exits 124 on expiry, reported as FAIL below rather than a hang.
+timeout "${KERNEL_TEST_TIMEOUT:-180}" torchrun --nnodes="$NNODES" --nproc-per-node=1 --node-rank="$NODE_RANK" \
+  --master-addr="$LEADER_IP" --master-port=29501 "$TEST" --num-processes "$GPUS_PER_NODE" \
+  --test-first-only --skip-perf-test 2>&1 | tee /tmp/kernel-test.$NODE_RANK.log
+rc=${PIPESTATUS[0]}
+
+# fail-loud contract: gate on the exit code (the test is assertion-based and prints no
+# pass marker — any grep for one would fail a genuinely green run), then separately
+# require the EFA transport banner.
+if [ "$rc" -eq 0 ]; then
+  # confirm EFA (not TCP/SHM) actually carried it — only provider-specific banners count;
+  # a bare "NET/OFI" line also prints for tcp;ofi_rxm fallback, the exact case to rule out
+  if grep -qiE "efa-direct|Selected Provider is efa" /tmp/kernel-test.$NODE_RANK.log; then
+    echo "KERNEL-TEST PASS (node_rank=$NODE_RANK) — DeepEP-V2 dispatch/combine over EFA verified"
+    exit 0
+  fi
+  echo "KERNEL-TEST INCONCLUSIVE: test passed but no EFA-provider banner in log — confirm transport before trusting"
+  exit 2
+fi
+echo "KERNEL-TEST FAIL (node_rank=$NODE_RANK, torchrun rc=$rc) — see /tmp/kernel-test.$NODE_RANK.log"
+exit 1

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/run-kernel-test.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/run-kernel-test.sh
@@ -27,7 +27,6 @@ export FI_PROVIDER=efa FI_EFA_USE_DEVICE_RDMA=1 FI_EFA_ENABLE_SHM_TRANSFER=0 FI_
 export OFI_NCCL_PROTOCOL=RDMA DEEP_EP_BACKEND=nccl
 export NCCL_NET_PLUGIN=/opt/aws-ofi-nccl/lib/libnccl-net-ofi.so
 export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-^lo,docker,veth}   # exclusion, never positive selection: EFA nodes expose efa*/enp* and CNI adds bridges; auto-select can pick a non-routing iface -> rendezvous hang. Repo convention (nccl-tests Dockerfile). Kept identical to serve.sh so this claim ("VERBATIM from serve.sh") stays true.
-export OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1
 export EP_REUSE_NCCL_COMM=0          # DeepEP own-comm (segfault rootcause 2026-08-14)
 export NCCL_DEBUG=${KERNEL_TEST_NCCL_DEBUG:-INFO}   # INFO so the efa-direct banner prints = transport proof
 

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/run-kernel-test.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/run-kernel-test.sh
@@ -36,7 +36,6 @@ export NCCL_DEBUG=${KERNEL_TEST_NCCL_DEBUG:-INFO}   # INFO so the efa-direct ban
 NODE_RANK="$NODE_RANK_ARG"; [ "$ROLE" = "leader" ] && NODE_RANK=0
 echo "===== DeepEP-V2 kernel smoke: role=$ROLE node_rank=$NODE_RANK nnodes=$NNODES gpus/node=$GPUS_PER_NODE leader=$LEADER_IP $(hostname) $(date -u +%FT%TZ) ====="
 
-set -o pipefail
 # ONE torchrun process per node: test_ep.py spawns its own local ranks internally
 # (torch.multiprocessing.spawn with --num-processes, default 8) and DeepEP's init_dist
 # reads WORLD_SIZE as a NODE count (num_nodes = WORLD_SIZE, world = nodes x local_ranks).
@@ -56,7 +55,10 @@ set -o pipefail
 # `timeout` remains as the hard safety bound (a wrong NNODES / a worker that never starts
 # / a stalled NCCL init blocks indefinitely otherwise); 180s is comfortably above the ~90s
 # measured runtime. timeout exits 124 on expiry, reported as FAIL below rather than a hang.
-timeout "${KERNEL_TEST_TIMEOUT:-180}" torchrun --nnodes="$NNODES" --nproc-per-node=1 --node-rank="$NODE_RANK" \
+# --kill-after=30: on expiry timeout signals torchrun ONLY; the spawned per-rank processes
+# can outlive it holding GPU memory (which the serve then contends with) — the SIGKILL
+# follow-up bounds that cleanup.
+timeout --kill-after=30 "${KERNEL_TEST_TIMEOUT:-180}" torchrun --nnodes="$NNODES" --nproc-per-node=1 --node-rank="$NODE_RANK" \
   --master-addr="$LEADER_IP" --master-port=29501 "$TEST" --num-processes "$GPUS_PER_NODE" \
   --test-first-only --skip-perf-test 2>&1 | tee /tmp/kernel-test.$NODE_RANK.log
 rc=${PIPESTATUS[0]}

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/run-kernel-test.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/run-kernel-test.sh
@@ -8,15 +8,18 @@
 #   leader:  run-kernel-test.sh leader <leader-ip>
 #   worker:  run-kernel-test.sh worker <leader-ip> <node-rank>   # node-rank 1,2,3 for the worker nodes
 #
-# Env (shared with serve.sh): NNODES (default 2), GPUS_PER_NODE (default 8).
+# Env (shared with serve.sh): SERVE_DP / SERVE_DP_LOCAL — the gate's NNODES / GPUS_PER_NODE
+# derive from them so the smoke always tests the SAME shape the serve will run (a 4-node
+# SERVE_DP=32 deployment must not smoke-test 2 nodes). Override NNODES/GPUS_PER_NODE only
+# to test a different shape deliberately.
 set -uo pipefail
 
 ROLE="${1:?usage: run-kernel-test.sh leader|worker <leader-ip> [node-rank]}"
 case "$ROLE" in leader|worker) ;; *) echo "FATAL: unrecognized role '$ROLE' (leader|worker)"; exit 2 ;; esac
 LEADER_IP="${2:?need leader ip}"
 if [ "$ROLE" = "worker" ]; then NODE_RANK_ARG="${3:?worker requires an explicit node-rank (1,2,...)}"; else NODE_RANK_ARG=0; fi
-NNODES="${NNODES:-2}"
-GPUS_PER_NODE="${GPUS_PER_NODE:-8}"
+NNODES="${NNODES:-$(( ${SERVE_DP:-16} / ${SERVE_DP_LOCAL:-8} ))}"
+GPUS_PER_NODE="${GPUS_PER_NODE:-${SERVE_DP_LOCAL:-8}}"
 TEST="/opt/DeepEP/tests/elastic/test_ep.py"
 [ -f "$TEST" ] || { echo "FAIL: $TEST not in image — rebuild from setup_deepep_v2_efa.sh"; exit 3; }
 

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/serve.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/serve.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+# serve.sh — NVIDIA Dynamo (frontend ingress + dynamo.vllm worker) DP/EP serve with the DeepEP-V2
+# all-to-all backend over AWS EFA (NCCL-GIN CPU-proxy). One invocation per NODE.
+#
+#   leader:  serve.sh leader <leader-pod-ip>                # node 0: dynamo.frontend + dynamo.vllm
+#   worker:  serve.sh worker <leader-pod-ip> <start-rank>   # node 1+: dynamo.vllm --headless (8 / 16 / 24 ...)
+#
+# Topology — how Dynamo composes with the proven vLLM-DeepEP-V2 substrate (nothing about the
+# transport changes; only the serving front is added):
+#   LEADER (node 0):
+#     (1) `dynamo.frontend` = the OpenAI-compatible HTTP ingress on :8000. It discovers the local
+#         engine via the file backend (DYN_DISCOVERY_BACKEND=file, DYN_FILE_KV) — a NODE-0-LOCAL
+#         path; it is NOT shared across nodes.
+#     (2) `dynamo.vllm` (non-headless) = the leader engine (DP ranks 0..local-1). It registers with
+#         the frontend over that file backend, then vLLM's OWN data-parallel coordinator (mp backend
+#         + --data-parallel-address) fans the expert all-to-all across ALL nodes over EFA.
+#   WORKER (node 1+):
+#     `dynamo.vllm --headless` -> vLLM run_headless(): the worker runs vLLM ONLY (no discovery, no
+#     dynamo endpoints); it joins the DP group purely through vLLM's data-parallel RPC to the leader
+#     — byte-identical to the `vllm serve --headless` worker in the sibling vLLM sample.
+# The ONLY delta vs the vLLM-DeepEP-V2 twin (../../vllm/deepep-v2-efa) is the dynamo.vllm wrapper +
+# dynamo.frontend ingress. The proxy-Gin/EFA env contract, the DP-coordinator flags, the model, and
+# the EP-divisibility preflight below are IDENTICAL to that sample (see README "Relationship to the
+# vLLM sample").
+#
+# Scale is env-driven (the proven 2-node DP16 default is byte-identical unless overridden):
+#   SERVE_DP=16|32...    total data-parallel size across all nodes (= EP size)
+#   SERVE_DP_LOCAL=8     ranks per node (= GPUs per node)
+#   SERVE_MODEL=...      any MoE whose n_routed_experts % SERVE_DP == 0 (preflighted below)
+#
+# ── EAGER vs DEFAULT COMPILATION (see README "eager vs non-eager") ──────────────
+# SERVE_ENFORCE_EAGER=1 (DEFAULT, and the ONLY supported mode at the shipped pin) — eager is
+#   what every measured E2E validation of this stack ran on: our H200 EP16/EP32 (2026-08-01,
+#   16/16 chat 200) AND the independent B200 EP16 run (0/384 request failures) — both at the
+#   shipped vLLM pin e2f993dc4. The benchmarks/ tables are this mode at this pin.
+# SERVE_ENFORCE_EAGER=0 — default (CUDA-graph) compilation. NOT supported at the shipped pin:
+#   at e2f993dc4, non-eager crashes deterministically ~48 s into startup in profile_run
+#   (Triton IMA in deepep_v2.py combine, via finalize_async). The empty-ExpertTokensMetadata
+#   guard that fixes it (vLLM #52632) landed only on the 0.26 line — and 0.26's deepep_v2
+#   combine separately faults CUDA_ERROR_LAUNCH_FAILED (719) in profile_run on this exact
+#   DeepEP/EFA substrate (measured 2026-09-04), so we cannot pin forward to get #52632 either.
+#   The historical non-eager benchmarks/ tables were taken on this pin with #52632 applied as
+#   an UNMERGED cherry-pick; reproducing them needs that patch. Leave this =1.
+set -euo pipefail   # -e: preflight failures below must STOP the launch, not fall through to the serve
+ROLE="${1:?usage: serve.sh leader|worker <leader-ip> [start-rank]}"; DP_MASTER_IP="${2:?need leader ip}"
+case "$ROLE" in leader|worker) ;; *) echo "FATAL: unrecognized role '$ROLE' (leader|worker)"; exit 2 ;; esac
+DP_MASTER_PORT="${DP_MASTER_PORT:-29500}"
+
+# ---- proxy-Gin + EFA env contract (identical to the measured runs + deploy YAML) ----
+export NCCL_GIN_TYPE=2 NCCL_GIN_ENABLE=1 OFI_NCCL_GIN_GDAKI=0 OFI_NCCL_GIN_MAX_REQUESTS=512
+export NCCL_CUMEM_ENABLE=1 NCCL_NVLS_ENABLE=0 NCCL_IGNORE_DISABLED_P2P=1
+export FI_PROVIDER=efa FI_EFA_USE_DEVICE_RDMA=1 FI_EFA_ENABLE_SHM_TRANSFER=0 FI_EFA_FORK_SAFE=1
+export OFI_NCCL_PROTOCOL=RDMA DEEP_EP_BACKEND=nccl
+export NCCL_NET_PLUGIN=/opt/aws-ofi-nccl/lib/libnccl-net-ofi.so
+export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-^lo,docker,veth}   # exclusion, never positive selection: EFA nodes expose efa*/enp* and CNI adds bridges; auto-select can pick a non-routing iface -> rendezvous hang. Repo convention (nccl-tests Dockerfile).
+export OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1   # PR#1351: assert forced-PCIe on gdrdrv-2.4-kernel nodes
+export EP_REUSE_NCCL_COMM=0   # DeepEP creates its own comm; torch's is lazy/null under vLLM (segfault rootcause 2026-08-14)
+export NCCL_DEBUG=${SERVE_NCCL_DEBUG:-WARN}
+# EP_EFA_MAX_QPS=2 is the value the published benchmarks/ numbers were measured with
+# (DeepEP PR#612's conservative EFA default: its commit message caps auto-QP at 2 to avoid
+# a 128-slot GIN request-ring overflow) — kept as the default so the sample reproduces its
+# own tables. It may leave throughput on the table on newer aws-ofi-nccl: that 128-slot ring
+# was replaced by the seq-window design upstream (6e504db), and the plugin pinned here
+# (9c44d34) is 76 commits PAST that redesign (github.com/aws/aws-ofi-nccl/compare/6e504db...9c44d34),
+# so the image is not in the condition the cap was written for; a 2x B200 A/B through this
+# same vLLM path measured +29% throughput / -23% p50 uncapped (=129) with 0/384 failures, so
+# uncapping is worth testing on p5en. If you tune it, re-measure at YOUR concurrency and
+# record the value — both knobs are part of the benchmark provenance table.
+export EP_EFA_MAX_QPS=${EP_EFA_MAX_QPS:-2} EP_EFA_RDMA_GBS=${EP_EFA_RDMA_GBS:-25.0}
+
+# ---- vLLM PR#41183 (DeepEPV2All2AllManager) envs — V2-native, shim OFF ----
+export DEEP_EP_USE_V2_SHIM=0
+export VLLM_USE_FLASHINFER_MOE_FP8=0
+export VLLM_ENGINE_READY_TIMEOUT_S=${VLLM_ENGINE_READY_TIMEOUT_S:-1800}
+export VLLM_DEEPEP_V2_ALLOW_HYBRID_MODE=1
+export VLLM_DEEPEP_V2_PREFER_OVERLAP=0
+export VLLM_DEEPEP_V2_ALLOW_MULTIPLE_REDUCTION=0
+
+# ---- Dynamo discovery: file backend, NODE-0-LOCAL (frontend <-> leader engine only) ----
+# The worker is --headless and never touches this path; cross-node fan-out is vLLM's native DP
+# coordinator (--data-parallel-address), so DYN_FILE_KV does NOT need a shared/cross-pod volume.
+export DYN_DISCOVERY_BACKEND=${DYN_DISCOVERY_BACKEND:-file}
+export DYN_FILE_KV=${DYN_FILE_KV:-/work/dynamo_store_kv}
+mkdir -p "$DYN_FILE_KV"
+
+# ---- HF cache on the pod-local writable volume (NOT the image layer) ----
+export HF_HOME=${HF_HOME:-/work/hf}
+export HUGGINGFACE_HUB_CACHE=${HUGGINGFACE_HUB_CACHE:-$HF_HOME/hub}
+mkdir -p "$HUGGINGFACE_HUB_CACHE"
+
+# ---- lib path: nvshmem + nccl wheels (namespace-pkg safe) + plugin + efa + cuda ----
+NVSHMEM_LIB="$(python3 -c 'import importlib.util,os
+s=importlib.util.find_spec("nvidia.nvshmem")
+p=(s.submodule_search_locations[0] if s and s.submodule_search_locations else None)
+print(os.path.join(p,"lib") if p else "")' 2>/dev/null || true)"
+NCCL_LIB="$(python3 -c 'import importlib.util,os
+s=importlib.util.find_spec("nvidia.nccl")
+p=(s.submodule_search_locations[0] if s and s.submodule_search_locations else None)
+print(os.path.join(p,"lib") if p else "")' 2>/dev/null || true)"
+export LD_LIBRARY_PATH="${NVSHMEM_LIB}:${NCCL_LIB}:/opt/aws-ofi-nccl/lib:/opt/amazon/efa/lib:/usr/local/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}"
+export PATH=/opt/amazon/efa/bin:$PATH
+
+# ---- scale + model (defaults = the measured EP16 2-node shape; identical to the vLLM sample) ----
+SERVE_MODEL="${SERVE_MODEL:-Qwen/Qwen3-30B-A3B-FP8}"
+# Pin the model REVISION too: --trust-remote-code (below) executes repo-side modeling code
+# in-pod, so an unpinned repo could change the code between preflight and load, or between
+# runs. Default = the measured commit of the default model; empty for any other SERVE_MODEL
+# (set SERVE_MODEL_REVISION to pin yours). Threaded into BOTH the preflight fetch and serve.
+if [ "$SERVE_MODEL" = "Qwen/Qwen3-30B-A3B-FP8" ]; then
+  SERVE_MODEL_REVISION="${SERVE_MODEL_REVISION:-d206ba732169f29bb77fbf80fc2c4b81d4d30782}"
+else
+  SERVE_MODEL_REVISION="${SERVE_MODEL_REVISION:-}"
+fi
+SERVE_DP="${SERVE_DP:-16}"
+SERVE_DP_LOCAL="${SERVE_DP_LOCAL:-8}"
+SERVE_TP="${SERVE_TP:-1}"
+START_RANK="${3:-$SERVE_DP_LOCAL}"   # derive from ranks/node (assigned above), not a hardcoded 8: a 4-GPU node wants worker ranks 4-7, not 8-11
+SERVE_MAX_MODEL_LEN="${SERVE_MAX_MODEL_LEN:-4096}"
+SERVE_MAX_NUM_SEQS="${SERVE_MAX_NUM_SEQS:-16}"
+SERVE_MAX_BATCHED_TOKENS="${SERVE_MAX_BATCHED_TOKENS:-256}"
+SERVE_GPU_MEM_UTIL="${SERVE_GPU_MEM_UTIL:-0.70}"
+HTTP_PORT="${HTTP_PORT:-8000}"       # dynamo.frontend OpenAI HTTP port
+
+# ---- EP-divisibility preflight (the one per-model gate): n_routed_experts % DP == 0 ----
+# Qwen3 family=128 (ok 16/32), DeepSeek-V3/R1=256 (ok), Kimi-K2=384 (ok), DeepSeek-V2-Lite=64 (ok),
+# Qwen1.5-MoE=60 (FAILS 16/32). Reads the model's config.json via huggingface_hub.
+if [ "${SKIP_EP_PREFLIGHT:-0}" != "1" ]; then
+  python3 - "$SERVE_MODEL" "$SERVE_DP" "$SERVE_MODEL_REVISION" <<'PY' || exit 3
+import json, sys
+from huggingface_hub import hf_hub_download
+model, dp = sys.argv[1], int(sys.argv[2])
+rev = sys.argv[3] if len(sys.argv) > 3 and sys.argv[3] else None   # pin the same revision the serve loads
+cfg = json.load(open(hf_hub_download(model, "config.json", revision=rev)))
+n = cfg.get("n_routed_experts") or cfg.get("num_experts")
+assert n, f"{model}: no n_routed_experts/num_experts in config.json — not a routed-MoE model?"
+assert n % dp == 0, (f"EP-DIVISIBILITY GATE FAILED: {model} has {n} routed experts, "
+                     f"not divisible by DP/EP={dp}. Pick a DP that divides {n} or another model.")
+print(f"EP preflight OK: {model} n_routed_experts={n} % DP={dp} == 0 ({n//dp} experts/rank)")
+PY
+fi
+
+# ---- eager / non-eager selection (see header + README "eager vs non-eager") ----
+# SERVE_ENFORCE_EAGER=1 (default) = eager, the ONLY supported mode at the shipped pin
+# (e2f993dc4) and the mode the published tables were measured with. =0 = default (CUDA-graph)
+# compilation, which at this pin crashes in profile_run (needs vLLM #52632, on the 0.26 line
+# only — and 0.26 regresses deepep_v2 combine here; see header + README "eager vs non-eager").
+SERVE_ENFORCE_EAGER="${SERVE_ENFORCE_EAGER:-1}"
+EAGER_FLAG="--enforce-eager"
+if [ "$SERVE_ENFORCE_EAGER" != "1" ]; then
+  echo "WARNING: SERVE_ENFORCE_EAGER=0 (default CUDA-graph compilation) is NOT supported at the shipped"
+  echo "  vLLM pin e2f993dc4 — it crashes deterministically in profile_run (needs the #52632 guard, which"
+  echo "  is only on the deepep_v2-combine-regressing 0.26 line). Proceeding as requested, but expect a crash."
+  EAGER_FLAG=""
+fi
+
+# --trust-remote-code is ON because the DeepSeek-V3/R1 + Kimi-K2 models serve.sh's preflight
+# supports execute repo-side modeling code from their HF repos; the default Qwen3-30B-A3B does
+# NOT need it. Kept unconditional because removing it breaks the DeepSeek/Kimi SERVE_MODEL path;
+# a SERVE_MODEL you do not trust should not be pointed at this serve. Because that code runs
+# in-pod, SERVE_MODEL_REVISION (above) pins WHICH commit's code executes — passed as --revision
+# so the served code matches the preflighted code and cannot drift between runs.
+REV_FLAG=""; [ -n "$SERVE_MODEL_REVISION" ] && REV_FLAG="--revision ${SERVE_MODEL_REVISION}"
+# COMMON = the DP/EP + AsyncEngineArgs flags. dynamo.vllm forwards every flag it does not itself
+# define straight into vLLM's AsyncEngineArgs (parse_known_args -> AsyncEngineArgs.from_cli_args),
+# so this block is IDENTICAL to the vLLM sample's COMMON — the DeepEP-V2 backend selection,
+# DP-coordinator wiring, and eager/revision flags all pass through unchanged.
+COMMON="--tensor-parallel-size ${SERVE_TP} --data-parallel-size ${SERVE_DP} --data-parallel-size-local ${SERVE_DP_LOCAL} \
+  --data-parallel-address ${DP_MASTER_IP} --data-parallel-rpc-port ${DP_MASTER_PORT} \
+  --data-parallel-backend mp --enable-expert-parallel --all2all-backend deepep_v2 \
+  ${EAGER_FLAG} ${REV_FLAG} --max-model-len ${SERVE_MAX_MODEL_LEN} --max-num-seqs ${SERVE_MAX_NUM_SEQS} \
+  --max-num-batched-tokens ${SERVE_MAX_BATCHED_TOKENS} \
+  --gpu-memory-utilization ${SERVE_GPU_MEM_UTIL} --trust-remote-code --dtype bfloat16"
+
+echo "===== Dynamo serve model=$SERVE_MODEL role=$ROLE tp=${SERVE_TP} dp=${SERVE_DP}/local${SERVE_DP_LOCAL} eager=${SERVE_ENFORCE_EAGER} start_rank=${START_RANK} dp_master=$DP_MASTER_IP http_port=${HTTP_PORT} $(hostname) $(date -u +%FT%TZ) ====="
+# import dynamo.vllm.MAIN (the serve entrypoint), not bare dynamo.vllm (whose __init__ imports no vLLM):
+# this resolves the full serve-path vLLM API surface against the pinned wheel, so a 0.22↔dynamo mismatch
+# fails HERE (seconds) rather than mid-load. main() is behind `if __name__` so importing it does not serve.
+python3 -c "import dynamo.vllm.main, dynamo.frontend, vllm, deep_ep; print('dynamo.vllm.main/frontend OK | vllm', vllm.__version__, '| deep_ep OK')"
+python3 -c "from vllm.distributed.device_communicators.all2all import DeepEPV2All2AllManager; print('PR#41183 symbol OK')"
+python3 -c "import deep_ep; assert hasattr(deep_ep,'ElasticBuffer'); print('deep_ep ElasticBuffer OK')"
+
+if [ "$ROLE" = "leader" ]; then
+  # (1) ingress: dynamo.frontend on 0.0.0.0:$HTTP_PORT. The pod runs WITHOUT hostNetwork and the
+  #     shipped headless Service is clusterIP:None with no external LB/NodePort — so 0.0.0.0 binds
+  #     only inside the pod's network namespace (reachable via cluster DNS / a `kubectl port-forward`,
+  #     NOT the host or the internet). The readinessProbe curls 127.0.0.1:$HTTP_PORT/health.
+  #     --discovery-backend file is passed EXPLICITLY (the arg default is etcd; the flag beats the
+  #     DYN_DISCOVERY_BACKEND env default and matches the proven invocation) so no etcd is needed.
+  LOG_DIR="${LOG_DIR:-/work/dynamo-serve}"; mkdir -p "$LOG_DIR"
+  python3 -m dynamo.frontend \
+    --discovery-backend file --http-host 0.0.0.0 --http-port "$HTTP_PORT" \
+    > "$LOG_DIR/frontend.log" 2>&1 &
+  FRONTEND_PID=$!
+  echo "dynamo.frontend PID $FRONTEND_PID -> $LOG_DIR/frontend.log (http 0.0.0.0:$HTTP_PORT)"
+  # If the frontend dies, the engine is unreachable — fail the pod rather than serve a black hole.
+  trap 'kill "$FRONTEND_PID" 2>/dev/null || true' EXIT
+  sleep 6
+  kill -0 "$FRONTEND_PID" 2>/dev/null || { echo "FATAL: dynamo.frontend exited during startup — see $LOG_DIR/frontend.log"; tail -20 "$LOG_DIR/frontend.log" || true; exit 4; }
+  # (2) leader engine: dynamo.vllm NON-headless (DP ranks 0..local-1). Registers with the frontend
+  #     over the file backend; vLLM's DP coordinator fans expert A2A across nodes over EFA.
+  #     --request-plane tcp + --event-plane zmq are the arg defaults, passed explicitly to match the
+  #     proven invocation. --kv-events-config disables KV-cache event publishing (no KV router here;
+  #     leaving it on makes the engine publish over zmq that nothing consumes).
+  exec python3 -m dynamo.vllm --model "$SERVE_MODEL" \
+    --discovery-backend file --request-plane tcp --event-plane zmq \
+    --kv-events-config '{"enable_kv_cache_events": false}' $COMMON
+else
+  # worker: dynamo.vllm --headless -> vLLM run_headless() (no discovery/endpoints, bypasses
+  # DistributedRuntime entirely — no NATS/etcd). --headless IS the multi-node mechanism for
+  # --data-parallel-backend mp (vLLM asserts nnodes>1 only under mp). It joins the DP group via
+  # vLLM's data-parallel RPC to the leader. start-rank = this node's DP rank offset
+  # (2-node DP16 -> 8 ; 4-node DP32 -> 8/16/24, one worker node each). No discovery flags: the
+  # headless worker never touches the discovery backend.
+  exec python3 -m dynamo.vllm --model "$SERVE_MODEL" --data-parallel-start-rank "$START_RANK" --headless $COMMON
+fi

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/serve.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/serve.sh
@@ -57,17 +57,11 @@ export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-^lo,docker,veth}   # exclusion, 
 export OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1   # PR#1351: assert forced-PCIe on gdrdrv-2.4-kernel nodes
 export EP_REUSE_NCCL_COMM=0   # DeepEP creates its own comm; torch's is lazy/null under vLLM (segfault rootcause 2026-08-14)
 export NCCL_DEBUG=${SERVE_NCCL_DEBUG:-WARN}
-# EP_EFA_MAX_QPS=2 is the value the published benchmarks/ numbers were measured with
-# (DeepEP PR#612's conservative EFA default: its commit message caps auto-QP at 2 to avoid
-# a 128-slot GIN request-ring overflow) — kept as the default so the sample reproduces its
-# own tables. It may leave throughput on the table on newer aws-ofi-nccl: that 128-slot ring
-# was replaced by the seq-window design upstream (6e504db), and the plugin pinned here
-# (9c44d34) is 76 commits PAST that redesign (github.com/aws/aws-ofi-nccl/compare/6e504db...9c44d34),
-# so the image is not in the condition the cap was written for; a 2x B200 A/B through this
-# same vLLM path measured +29% throughput / -23% p50 uncapped (=129) with 0/384 failures, so
-# uncapping is worth testing on p5en. If you tune it, re-measure at YOUR concurrency and
-# record the value — both knobs are part of the benchmark provenance table.
-export EP_EFA_MAX_QPS=${EP_EFA_MAX_QPS:-2} EP_EFA_RDMA_GBS=${EP_EFA_RDMA_GBS:-25.0}
+# QP sizing + RDMA link rate need no env at the shipped DeepEP pin: the amazon-contributing
+# fork clamps the QP count into [_C.min_unordered_gin_qps, _C.max_unordered_gin_qps]
+# (deep_ep/buffers/elastic.py) and probes the link rate from sysfs (deep_ep/utils/envs.py
+# _get_sysfs_rdma_gbs). The old EP_EFA_MAX_QPS / EP_EFA_RDMA_GBS knobs from deepseek PR#612
+# do not exist on this source and are deliberately not exported.
 
 # ---- vLLM PR#41183 (DeepEPV2All2AllManager) envs — V2-native, shim OFF ----
 export DEEP_EP_USE_V2_SHIM=0

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/serve.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/serve.sh
@@ -54,7 +54,6 @@ export FI_PROVIDER=efa FI_EFA_USE_DEVICE_RDMA=1 FI_EFA_ENABLE_SHM_TRANSFER=0 FI_
 export OFI_NCCL_PROTOCOL=RDMA DEEP_EP_BACKEND=nccl
 export NCCL_NET_PLUGIN=/opt/aws-ofi-nccl/lib/libnccl-net-ofi.so
 export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-^lo,docker,veth}   # exclusion, never positive selection: EFA nodes expose efa*/enp* and CNI adds bridges; auto-select can pick a non-routing iface -> rendezvous hang. Repo convention (nccl-tests Dockerfile).
-export OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1   # PR#1351: assert forced-PCIe on gdrdrv-2.4-kernel nodes
 export EP_REUSE_NCCL_COMM=0   # DeepEP creates its own comm; torch's is lazy/null under vLLM (segfault rootcause 2026-08-14)
 export NCCL_DEBUG=${SERVE_NCCL_DEBUG:-WARN}
 # QP sizing + RDMA link rate need no env at the shipped DeepEP pin: the amazon-contributing

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/serve.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/serve.sh
@@ -27,7 +27,7 @@
 # Scale is env-driven (the proven 2-node DP16 default is byte-identical unless overridden):
 #   SERVE_DP=16|32...    total data-parallel size across all nodes (= EP size)
 #   SERVE_DP_LOCAL=8     ranks per node (= GPUs per node)
-#   SERVE_MODEL=...      any MoE whose n_routed_experts % SERVE_DP == 0 (preflighted below)
+#   SERVE_MODEL=...      any MoE whose n_routed_experts % (SERVE_DP x SERVE_TP) == 0 (preflighted below)
 #
 # ── EAGER vs DEFAULT COMPILATION (see README "eager vs non-eager") ──────────────
 # SERVE_ENFORCE_EAGER=1 (DEFAULT, and the ONLY supported mode at the shipped pin) — eager is
@@ -108,18 +108,23 @@ fi
 SERVE_DP="${SERVE_DP:-16}"
 SERVE_DP_LOCAL="${SERVE_DP_LOCAL:-8}"
 SERVE_TP="${SERVE_TP:-1}"
-START_RANK="${3:-$SERVE_DP_LOCAL}"   # derive from ranks/node (assigned above), not a hardcoded 8: a 4-GPU node wants worker ranks 4-7, not 8-11
+# A worker's start-rank must be EXPLICIT: a default (e.g. $SERVE_DP_LOCAL) is right only for
+# the 2-node shape — at 3+ nodes every defaulted worker would claim the same rank window and
+# collide in the DP rendezvous instead of failing at startup. Leader owns ranks 0..local-1.
+if [ "$ROLE" = "worker" ]; then START_RANK="${3:?worker requires an explicit DP start-rank (= node ordinal x SERVE_DP_LOCAL: 8, 16, 24 ...)}"; else START_RANK=0; fi
 SERVE_MAX_MODEL_LEN="${SERVE_MAX_MODEL_LEN:-4096}"
 SERVE_MAX_NUM_SEQS="${SERVE_MAX_NUM_SEQS:-16}"
 SERVE_MAX_BATCHED_TOKENS="${SERVE_MAX_BATCHED_TOKENS:-256}"
 SERVE_GPU_MEM_UTIL="${SERVE_GPU_MEM_UTIL:-0.70}"
 HTTP_PORT="${HTTP_PORT:-8000}"       # dynamo.frontend OpenAI HTTP port
 
-# ---- EP-divisibility preflight (the one per-model gate): n_routed_experts % DP == 0 ----
+# ---- EP-divisibility preflight (the one per-model gate): n_routed_experts % (DP×TP) == 0 ----
+# vLLM's expert-parallel group is DP × TP, not DP alone (docs/serving/data_parallel_deployment.md:
+# "expert layers form a group of size DP × TP"); at the shipped SERVE_TP=1 the product equals DP.
 # Qwen3 family=128 (ok 16/32), DeepSeek-V3/R1=256 (ok), Kimi-K2=384 (ok), DeepSeek-V2-Lite=64 (ok),
 # Qwen1.5-MoE=60 (FAILS 16/32). Reads the model's config.json via huggingface_hub.
 if [ "${SKIP_EP_PREFLIGHT:-0}" != "1" ]; then
-  python3 - "$SERVE_MODEL" "$SERVE_DP" "$SERVE_MODEL_REVISION" <<'PY' || exit 3
+  python3 - "$SERVE_MODEL" "$((SERVE_DP * SERVE_TP))" "$SERVE_MODEL_REVISION" <<'PY' || exit 3
 import json, sys
 from huggingface_hub import hf_hub_download
 model, dp = sys.argv[1], int(sys.argv[2])
@@ -131,6 +136,17 @@ assert n % dp == 0, (f"EP-DIVISIBILITY GATE FAILED: {model} has {n} routed exper
                      f"not divisible by DP/EP={dp}. Pick a DP that divides {n} or another model.")
 print(f"EP preflight OK: {model} n_routed_experts={n} % DP={dp} == 0 ({n//dp} experts/rank)")
 PY
+fi
+
+# ---- per-node GPU-fit preflight: SERVE_TP × SERVE_DP_LOCAL ranks land on THIS node ----
+# The other way the TP knob produces a late failure: vLLM only discovers an over-committed
+# node at engine start. Skipped when no GPU is visible (e.g. linting the script off-node).
+if command -v nvidia-smi >/dev/null 2>&1; then
+  NUM_GPUS="$(nvidia-smi -L 2>/dev/null | grep -c '^GPU' || true)"
+  if [ "${NUM_GPUS:-0}" -gt 0 ] && [ "$((SERVE_TP * SERVE_DP_LOCAL))" -gt "$NUM_GPUS" ]; then
+    echo "FATAL: SERVE_TP(${SERVE_TP}) x SERVE_DP_LOCAL(${SERVE_DP_LOCAL}) = $((SERVE_TP * SERVE_DP_LOCAL)) GPUs/node needed; this node has ${NUM_GPUS}"
+    exit 3
+  fi
 fi
 
 # ---- eager / non-eager selection (see header + README "eager vs non-eager") ----

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/serve.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/serve.sh
@@ -182,10 +182,11 @@ COMMON="--tensor-parallel-size ${SERVE_TP} --data-parallel-size ${SERVE_DP} --da
   --gpu-memory-utilization ${SERVE_GPU_MEM_UTIL} --trust-remote-code --dtype bfloat16"
 
 echo "===== Dynamo serve model=$SERVE_MODEL role=$ROLE tp=${SERVE_TP} dp=${SERVE_DP}/local${SERVE_DP_LOCAL} eager=${SERVE_ENFORCE_EAGER} start_rank=${START_RANK} dp_master=$DP_MASTER_IP http_port=${HTTP_PORT} $(hostname) $(date -u +%FT%TZ) ====="
-# import dynamo.vllm.MAIN (the serve entrypoint), not bare dynamo.vllm (whose __init__ imports no vLLM):
-# this resolves the full serve-path vLLM API surface against the pinned wheel, so a 0.22↔dynamo mismatch
-# fails HERE (seconds) rather than mid-load. main() is behind `if __name__` so importing it does not serve.
-python3 -c "import dynamo.vllm.main, dynamo.frontend, vllm, deep_ep; print('dynamo.vllm.main/frontend OK | vllm', vllm.__version__, '| deep_ep OK')"
+# import dynamo.vllm.MAIN and dynamo.frontend.MAIN (the real entrypoints), not the bare packages
+# (both __init__s are version shims that import no vLLM, so they would gate nothing): this resolves
+# the full serve-path vLLM API surface against the pinned wheel, so a 0.22↔dynamo mismatch fails
+# HERE (seconds) rather than mid-load. main() is behind `if __name__` so importing it does not serve.
+python3 -c "import dynamo.vllm.main, dynamo.frontend.main, vllm, deep_ep; print('dynamo.vllm.main/frontend.main OK | vllm', vllm.__version__, '| deep_ep OK')"
 python3 -c "from vllm.distributed.device_communicators.all2all import DeepEPV2All2AllManager; print('PR#41183 symbol OK')"
 python3 -c "import deep_ep; assert hasattr(deep_ep,'ElasticBuffer'); print('deep_ep ElasticBuffer OK')"
 

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/serve.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/serve.sh
@@ -186,9 +186,14 @@ echo "===== Dynamo serve model=$SERVE_MODEL role=$ROLE tp=${SERVE_TP} dp=${SERVE
 # (both __init__s are version shims that import no vLLM, so they would gate nothing): this resolves
 # the full serve-path vLLM API surface against the pinned wheel, so a 0.22↔dynamo mismatch fails
 # HERE (seconds) rather than mid-load. main() is behind `if __name__` so importing it does not serve.
-python3 -c "import dynamo.vllm.main, dynamo.frontend.main, vllm, deep_ep; print('dynamo.vllm.main/frontend.main OK | vllm', vllm.__version__, '| deep_ep OK')"
-python3 -c "from vllm.distributed.device_communicators.all2all import DeepEPV2All2AllManager; print('PR#41183 symbol OK')"
-python3 -c "import deep_ep; assert hasattr(deep_ep,'ElasticBuffer'); print('deep_ep ElasticBuffer OK')"
+# One interpreter start for every preflight assert: each separate python3 -c pays the full
+# ~30-60 s torch+vLLM import on every pod start on every node; three of them tripled that.
+python3 -c "
+import dynamo.vllm.main, dynamo.frontend.main, vllm, deep_ep
+from vllm.distributed.device_communicators.all2all import DeepEPV2All2AllManager
+assert hasattr(deep_ep, 'ElasticBuffer'), 'deep_ep has no ElasticBuffer (V1 source?)'
+print('dynamo.vllm.main/frontend.main OK | vllm', vllm.__version__, '| PR#41183 symbol OK | ElasticBuffer OK')
+"
 
 if [ "$ROLE" = "leader" ]; then
   # (1) ingress: dynamo.frontend on 0.0.0.0:$HTTP_PORT. The pod runs WITHOUT hostNetwork and the
@@ -203,7 +208,10 @@ if [ "$ROLE" = "leader" ]; then
     > "$LOG_DIR/frontend.log" 2>&1 &
   FRONTEND_PID=$!
   echo "dynamo.frontend PID $FRONTEND_PID -> $LOG_DIR/frontend.log (http 0.0.0.0:$HTTP_PORT)"
-  # If the frontend dies, the engine is unreachable — fail the pod rather than serve a black hole.
+  # Scope of this trap: ONLY the window between here and the `exec` below — bash does not run
+  # EXIT traps across exec, so this reaps the frontend if a remaining startup step fails (the
+  # exit 4 below), nothing more. The runtime guarantee ("frontend dies => pod fails, not a
+  # black hole") is the manifest's leader livenessProbe, not this trap.
   trap 'kill "$FRONTEND_PID" 2>/dev/null || true' EXIT
   sleep 6
   kill -0 "$FRONTEND_PID" 2>/dev/null || { echo "FATAL: dynamo.frontend exited during startup — see $LOG_DIR/frontend.log"; tail -20 "$LOG_DIR/frontend.log" || true; exit 4; }

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/verify-image.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/verify-image.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+# Smoke the EFA + DeepEP-V2 substrate in the built image BEFORE loading a model. Fails loud.
+# Static image check: asserts exactly what the image stages. The DeepEP _C.so is built
+# IN-POD on first boot (build_deepep.sh — needs a live CUDA context), so `import deep_ep`
+# is deliberately NOT asserted here; the staged source + the transport substrate are.
+set -euo pipefail
+IMG="${1:?usage: verify-image.sh <image>}"
+
+# EFA device mapping: fi_info -p efa only resolves with the device visible in the
+# container. On an EFA host, pass /dev/infiniband through; elsewhere fall back to a
+# provider-compiled-in check (fi_info -l) and say so.
+DEV_ARGS=()
+HAVE_EFA_DEV=0
+if [ -d /dev/infiniband ]; then
+  DEV_ARGS=(-v /dev/infiniband:/dev/infiniband --device=/dev/infiniband)
+  HAVE_EFA_DEV=1
+fi
+
+docker run --rm --gpus all "${DEV_ARGS[@]}" -e HAVE_EFA_DEV="${HAVE_EFA_DEV}" "${IMG}" bash -lc '
+  set -euo pipefail
+  if [ "${HAVE_EFA_DEV}" = "1" ]; then
+    echo "== fi_info efa (live fabric) =="
+    [ "$(/opt/amazon/efa/bin/fi_info -p efa | grep -c "fabric: efa-direct")" -ge 1 ] || { echo "FAIL: no efa-direct"; exit 1; }
+  else
+    echo "== fi_info efa (no /dev/infiniband on this host — checking provider is compiled in only) =="
+    /opt/amazon/efa/bin/fi_info -l | grep -qi "efa" || { echo "FAIL: efa provider not in libfabric"; exit 1; }
+    echo "   (run this script on an EFA host for the live efa-direct fabric check)"
+  fi
+  echo "== single libnccl 2.30.4 wins (path + GIN/LSA symbol — the wheel downgrade lands in the SAME dir, so path alone cannot catch it) =="
+  NCCL_SO=$(ldconfig -p | grep "libnccl.so.2 " | head -1 | awk "{print \$NF}")
+  echo "$NCCL_SO" | grep -q "nvidia/nccl" || { echo "FAIL: system libnccl shadows pip ($NCCL_SO)"; exit 1; }
+  [ "$(nm -D "$NCCL_SO" | grep -c ncclGetLsaDevicePointer)" -ge 1 ] || { echo "FAIL: $NCCL_SO lacks GIN/LSA symbols (2.28.x downgrade — see Dockerfile Layer 5b)"; exit 1; }
+  echo "== GIN plugin symbol =="; [ "$(nm -D /opt/aws-ofi-nccl/lib/libnccl-net-ofi.so | grep -c ncclGinPlugin)" -ge 1 ] || { echo "FAIL: no ncclGinPlugin"; exit 1; }
+  echo "== DeepEP-V2 source staged (built in-pod on first boot; import is asserted there, not here) =="
+  test -f /opt/DeepEP/deep_ep/buffers/elastic.py || { echo "FAIL: /opt/DeepEP not staged"; exit 1; }
+  grep -q "class ElasticBuffer" /opt/DeepEP/deep_ep/buffers/elastic.py || { echo "FAIL: staged DeepEP has no ElasticBuffer (V1 source?)"; exit 1; }
+  test -f /opt/DeepEP/tests/elastic/test_ep.py || { echo "FAIL: kernel-smoke test not staged"; exit 1; }
+  echo "ALL CHECKS PASS"
+'

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/verify-image.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/recipe/verify-image.sh
@@ -17,7 +17,9 @@ if [ -d /dev/infiniband ]; then
   HAVE_EFA_DEV=1
 fi
 
-docker run --rm --gpus all "${DEV_ARGS[@]}" -e HAVE_EFA_DEV="${HAVE_EFA_DEV}" "${IMG}" bash -lc '
+# no --gpus: every check below is fi_info/ldconfig/nm/test/grep — none touches a GPU, so this
+# static check also runs on a build/CI host without the nvidia container toolkit.
+docker run --rm "${DEV_ARGS[@]}" -e HAVE_EFA_DEV="${HAVE_EFA_DEV}" "${IMG}" bash -lc '
   set -euo pipefail
   if [ "${HAVE_EFA_DEV}" = "1" ]; then
     echo "== fi_info efa (live fabric) =="
@@ -28,7 +30,8 @@ docker run --rm --gpus all "${DEV_ARGS[@]}" -e HAVE_EFA_DEV="${HAVE_EFA_DEV}" "$
     echo "   (run this script on an EFA host for the live efa-direct fabric check)"
   fi
   echo "== single libnccl 2.30.4 wins (path + GIN/LSA symbol — the wheel downgrade lands in the SAME dir, so path alone cannot catch it) =="
-  NCCL_SO=$(ldconfig -p | grep "libnccl.so.2 " | head -1 | awk "{print \$NF}")
+  NCCL_SO=$(ldconfig -p | grep "libnccl.so.2 " | head -1 | awk "{print \$NF}" || true)
+  [ -n "$NCCL_SO" ] || { echo "FAIL: no libnccl.so.2 on the linker path at all"; exit 1; }   # fail LOUD like every other check — a bare set -e death here printed nothing
   echo "$NCCL_SO" | grep -q "nvidia/nccl" || { echo "FAIL: system libnccl shadows pip ($NCCL_SO)"; exit 1; }
   [ "$(nm -D "$NCCL_SO" | grep -c ncclGetLsaDevicePointer)" -ge 1 ] || { echo "FAIL: $NCCL_SO lacks GIN/LSA symbols (2.28.x downgrade — see Dockerfile Layer 5b)"; exit 1; }
   echo "== GIN plugin symbol =="; [ "$(nm -D /opt/aws-ofi-nccl/lib/libnccl-net-ofi.so | grep -c ncclGinPlugin)" -ge 1 ] || { echo "FAIL: no ncclGinPlugin"; exit 1; }

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/setup/build-push.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/setup/build-push.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+set -euo pipefail
+cd "$(dirname "$0")/.."
+[ -f setup/env_vars ] || { echo "FATAL: cp setup/env_vars.example setup/env_vars and edit it first"; exit 2; }
+source setup/env_vars
+: "${REGISTRY:?set REGISTRY in setup/env_vars}"
+IMG="${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
+aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${REGISTRY}"
+DOCKER_BUILDKIT=1 docker build ${AWS_OFI_NCCL_PR_SHA:+--build-arg AWS_OFI_NCCL_PR_SHA="${AWS_OFI_NCCL_PR_SHA}"} -t "${IMG}" .
+docker push "${IMG}"
+echo "pushed ${IMG}"

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/setup/build-push.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/setup/build-push.sh
@@ -5,8 +5,13 @@ cd "$(dirname "$0")/.."
 [ -f setup/env_vars ] || { echo "FATAL: cp setup/env_vars.example setup/env_vars and edit it first"; exit 2; }
 source setup/env_vars
 : "${REGISTRY:?set REGISTRY in setup/env_vars}"
+: "${IMAGE_NAME:?set IMAGE_NAME in setup/env_vars}"
+: "${IMAGE_TAG:?set IMAGE_TAG in setup/env_vars}"
+: "${AWS_REGION:?set AWS_REGION in setup/env_vars}"
 IMG="${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
 aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${REGISTRY}"
-DOCKER_BUILDKIT=1 docker build -t "${IMG}" .
+# --platform: the image targets x86 p5en nodes; on an arm64 workstation an unplatformed build
+# fails four layers in (Layer-5 manylinux x86_64 wheel), this fails at Layer 1 with the cause named.
+DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -t "${IMG}" .
 docker push "${IMG}"
 echo "pushed ${IMG}"

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/setup/build-push.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/setup/build-push.sh
@@ -7,6 +7,6 @@ source setup/env_vars
 : "${REGISTRY:?set REGISTRY in setup/env_vars}"
 IMG="${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"
 aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${REGISTRY}"
-DOCKER_BUILDKIT=1 docker build ${AWS_OFI_NCCL_PR_SHA:+--build-arg AWS_OFI_NCCL_PR_SHA="${AWS_OFI_NCCL_PR_SHA}"} -t "${IMG}" .
+DOCKER_BUILDKIT=1 docker build -t "${IMG}" .
 docker push "${IMG}"
 echo "pushed ${IMG}"

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/setup/env_vars.example
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/setup/env_vars.example
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+# Copy to setup/env_vars (gitignored) and edit. Sourced by setup/build-push.sh; `source setup/env_vars` before running recipe/*.sh from a shell (in-pod, the manifest env supplies these).
+export REGISTRY="<your-account-id>.dkr.ecr.<your-region>.amazonaws.com"   # YOUR ECR — no registry is hardcoded anywhere
+export IMAGE_NAME="dynamo-deepep-v2-efa"
+# Immutable tag — never "latest": with the manifest's imagePullPolicy: IfNotPresent, a
+# node that cached "latest" silently keeps running the OLD image after a rebuild-and-push.
+# Bump the tag on every rebuild (date or git SHA both work).
+export IMAGE_TAG="v2-20260904"   # bump on every rebuild; keep in sync with kubernetes/ image:
+export AWS_REGION="us-east-2"
+# aws-ofi-nccl PR#1351 (OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY param) is pinned at its immutable
+# head SHA in the Dockerfile. Set a real alternate SHA here ONLY to test a newer PR head —
+# an empty/unset value does NOT skip the cherry-pick; the ${AWS_OFI_NCCL_PR_SHA:-<pin>}
+# default reinstates the pinned SHA.
+# export AWS_OFI_NCCL_PR_SHA=<alternate-immutable-sha>
+# Model: any MoE whose n_routed_experts % (data-parallel size) == 0. Default is public (no HF token).
+export SERVE_MODEL="Qwen/Qwen3-30B-A3B-FP8"
+export SERVE_DP="16"        # total data-parallel = EP size
+export SERVE_DP_LOCAL="8"   # GPUs per node

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/setup/env_vars.example
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/setup/env_vars.example
@@ -7,7 +7,7 @@ export IMAGE_NAME="dynamo-deepep-v2-efa"
 # Bump the tag on every rebuild (date or git SHA both work).
 export IMAGE_TAG="v2-20260904"   # bump on every rebuild; keep in sync with kubernetes/ image:
 export AWS_REGION="us-east-2"
-# Model: any MoE whose n_routed_experts % (data-parallel size) == 0. Default is public (no HF token).
+# Model: any MoE whose n_routed_experts % (DP x TP) == 0 (TP defaults to 1, so = DP). Default is public (no HF token).
 export SERVE_MODEL="Qwen/Qwen3-30B-A3B-FP8"
 export SERVE_DP="16"        # total data-parallel = EP size
 export SERVE_DP_LOCAL="8"   # GPUs per node

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/setup/env_vars.example
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/setup/env_vars.example
@@ -7,11 +7,6 @@ export IMAGE_NAME="dynamo-deepep-v2-efa"
 # Bump the tag on every rebuild (date or git SHA both work).
 export IMAGE_TAG="v2-20260904"   # bump on every rebuild; keep in sync with kubernetes/ image:
 export AWS_REGION="us-east-2"
-# aws-ofi-nccl PR#1351 (OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY param) is pinned at its immutable
-# head SHA in the Dockerfile. Set a real alternate SHA here ONLY to test a newer PR head —
-# an empty/unset value does NOT skip the cherry-pick; the ${AWS_OFI_NCCL_PR_SHA:-<pin>}
-# default reinstates the pinned SHA.
-# export AWS_OFI_NCCL_PR_SHA=<alternate-immutable-sha>
 # Model: any MoE whose n_routed_experts % (data-parallel size) == 0. Default is public (no HF token).
 export SERVE_MODEL="Qwen/Qwen3-30B-A3B-FP8"
 export SERVE_DP="16"        # total data-parallel = EP size

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/setup_deepep_v2_efa.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/setup_deepep_v2_efa.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: MIT-0
+#
+# setup_deepep_v2_efa.sh — build aws-ofi-nccl (GIN CPU-proxy) + stage DeepEP-V2 source for the
+# vLLM deepep_v2 backend on EFA. Distinct from the NVSHMEM-path setup_deepep_efa.sh (which pins
+# DeepEP 567632d and is gated by .github/workflows/deepep-vendor-sync.yml) — this is the V2 /
+# NCCL-GIN counterpart and is intentionally NOT vendor-synced to that canonical copy.
+#
+# Runs inside the Docker build. The DeepEP _C.so itself is compiled IN-POD at first boot
+# (recipe/build_deepep.sh) because it needs a live CUDA context the build sandbox lacks.
+set -euo pipefail
+
+# ---- pins (every one justified; no 'latest'; a bare refs/pull/N/head is a MOVING ref) ----
+AWS_OFI_NCCL_REPO="${AWS_OFI_NCCL_REPO:-https://github.com/aws/aws-ofi-nccl.git}"
+AWS_OFI_NCCL_SHA="${AWS_OFI_NCCL_SHA:-9c44d34476f90ddbf4a12d0ac4fc412d46bd8ab4}"  # GIN plugin, gdrdrv-2.4 v1-fallback baked
+AWS_OFI_NCCL_PR="${AWS_OFI_NCCL_PR:-1351}"                                       # OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY param
+AWS_OFI_NCCL_PR_SHA="${AWS_OFI_NCCL_PR_SHA:-c2e773dfb2c75b765b3415f8ffd1b47e7c239a7b}"  # IMMUTABLE PR#1351 head (a bare refs/pull/N/head is a moving ref)
+# DeepEP source divergence from the canonical setup_deepep_gin.sh (deepep-v2-benchmark): the canonical
+# pins the amazon-contributing/DeepEP fork; this sample pins deepseek-ai/DeepEP@b306af06 + PR#612 — the
+# substrate the shipped H200 (sm_90) numbers were measured on. The cost is Blackwell-only: the fork
+# carries the st.bulk 64-bit-operand fix (amazon-contributing/DeepEP#3, merged 2026-08-24) that makes
+# CUDA 13.0 codegen work on p6/Blackwell; this pin does not, so the manifest's DEEPEP_ARCH_LIST=10.x
+# knobs are documented-not-verified (README "Known limitations"). To enable Blackwell, set
+# DEEPEP_REPO=https://github.com/amazon-contributing/DeepEP.git + a fork SHA and re-verify on p6.
+DEEPEP_REPO="${DEEPEP_REPO:-https://github.com/deepseek-ai/DeepEP.git}"
+DEEPEP_SHA="${DEEPEP_SHA:-b306af06afd412c88e51e71802951606e40b7358}"            # measured substrate base (H200 sm_90)
+DEEPEP_PR="${DEEPEP_PR:-612}"                                                    # EFA auto-QP cap
+DEEPEP_PR_SHA="${DEEPEP_PR_SHA:-28d1f7fb173f728be51632ce0026fea23243e350}"       # IMMUTABLE PR#612 head (moving-ref trap)
+
+echo "== aws-ofi-nccl GIN @ ${AWS_OFI_NCCL_SHA} + PR#${AWS_OFI_NCCL_PR} =="
+git clone "${AWS_OFI_NCCL_REPO}" /opt/aws-ofi-nccl-src
+cd /opt/aws-ofi-nccl-src
+git config user.email build@local; git config user.name build
+git fetch origin "${AWS_OFI_NCCL_SHA}"; git checkout "${AWS_OFI_NCCL_SHA}"
+grep -q FALLBACK_V1_FOR_GDRDRV_24 src/nccl_ofi_gdrcopy.cpp   # assert the v1-fallback is present (fail-loud)
+if [ -n "${AWS_OFI_NCCL_PR_SHA}" ]; then
+  git fetch origin "${AWS_OFI_NCCL_PR_SHA}"
+  git cherry-pick "${AWS_OFI_NCCL_PR_SHA}"
+  grep -q GDRCOPY_FORCED_PCIE_COPY include/nccl_ofi_param.h  # assert the param landed (fail-loud)
+fi
+./autogen.sh
+./configure --prefix=/opt/aws-ofi-nccl --with-libfabric=/opt/amazon/efa --with-cuda=/usr/local/cuda \
+  --with-nccl-headers="$(python3 -c 'import nvidia.nccl; print(nvidia.nccl.__path__[0])')/include" \
+  --enable-cudart-dynamic --enable-platform-aws
+make -C src -j"$(nproc)"; make -C src install
+test -f /opt/aws-ofi-nccl/lib/libnccl-net-ofi.so
+[ "$(nm -D /opt/aws-ofi-nccl/lib/libnccl-net-ofi.so | grep -c ncclGinPlugin)" -ge 1 ]  # GIN symbol present (fail-loud)
+# GIN needs gdrcopy COMPILED IN (gdrapi.h at configure time) — a gdrapi-less build carries this
+# exact runtime-warn string and fails nccl_ofi_gin_init at serve with ginType==NONE. Assert absence.
+[ "$(strings /opt/aws-ofi-nccl/lib/libnccl-net-ofi.so | grep -c 'GDRCopy support not available at compile time')" -eq 0 ]
+ldconfig
+cd /; rm -rf /opt/aws-ofi-nccl-src
+
+echo "== DeepEP-V2 source @ ${DEEPEP_SHA} + PR#${DEEPEP_PR} (@ ${DEEPEP_PR_SHA}) =="
+git clone "${DEEPEP_REPO}" /opt/DeepEP
+cd /opt/DeepEP
+git config user.email build@local; git config user.name build
+git fetch origin "${DEEPEP_SHA}"; git checkout "${DEEPEP_SHA}"
+git fetch origin "${DEEPEP_PR_SHA}"
+git merge --no-edit "${DEEPEP_PR_SHA}"                       # pin the IMMUTABLE PR head, not the moving ref
+git rev-parse HEAD > /opt/deepep.effective.sha
+test -f /opt/DeepEP/tests/elastic/test_ep.py
+test -f /opt/DeepEP/csrc/elastic/buffer.hpp
+echo "== setup_deepep_v2_efa.sh complete; DeepEP _C.so builds in-pod via recipe/build_deepep.sh =="

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/setup_deepep_v2_efa.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/setup_deepep_v2_efa.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 # the pip NCCL headers — which is why no --with-nccl-headers flag is needed (and why
 # that flag, not being an AC_ARG_WITH this project defines, was silently ignored before).
 AWS_OFI_NCCL_REPO="${AWS_OFI_NCCL_REPO:-https://github.com/aws/aws-ofi-nccl.git}"
-AWS_OFI_NCCL_REF="${AWS_OFI_NCCL_REF:-v1.21.1}"
+AWS_OFI_NCCL_REF="${AWS_OFI_NCCL_REF:?pass from the Dockerfile ARG — the pin has ONE home there; a default here would be an unreachable second copy}"
 # DeepEP source = the amazon-contributing fork, same as the canonical setup_deepep_gin.sh
 # (deepep-v2-benchmark), which pins this fork and states "the benchmark supports no other
 # source". The fork carries the in-tree successors of deepseek PR#612's EFA work — the QP
@@ -30,7 +30,7 @@ AWS_OFI_NCCL_REF="${AWS_OFI_NCCL_REF:-v1.21.1}"
 # RDMA link rate is probed from sysfs (envs.py _get_sysfs_rdma_gbs) — plus the Blackwell
 # st.bulk 64-bit-operand fix (e3fd4361), so no EP_EFA_MAX_QPS/EP_EFA_RDMA_GBS env exists here.
 DEEPEP_REPO="${DEEPEP_REPO:-https://github.com/amazon-contributing/DeepEP.git}"
-DEEPEP_SHA="${DEEPEP_SHA:-97d8f9bcc1be31e9036db2ab591ef9b9f4e38619}"            # amazon-contributing/DeepEP@main, 2026-09-03
+DEEPEP_SHA="${DEEPEP_SHA:?pass from the Dockerfile ARG — the pin has ONE home there; a default here would be an unreachable second copy}"
 
 echo "== aws-ofi-nccl GIN @ ${AWS_OFI_NCCL_REF} =="
 git clone --depth 1 --branch "${AWS_OFI_NCCL_REF}" "${AWS_OFI_NCCL_REPO}" /opt/aws-ofi-nccl-src

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/setup_deepep_v2_efa.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/setup_deepep_v2_efa.sh
@@ -15,17 +15,14 @@ AWS_OFI_NCCL_REPO="${AWS_OFI_NCCL_REPO:-https://github.com/aws/aws-ofi-nccl.git}
 AWS_OFI_NCCL_SHA="${AWS_OFI_NCCL_SHA:-9c44d34476f90ddbf4a12d0ac4fc412d46bd8ab4}"  # GIN plugin, gdrdrv-2.4 v1-fallback baked
 AWS_OFI_NCCL_PR="${AWS_OFI_NCCL_PR:-1351}"                                       # OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY param
 AWS_OFI_NCCL_PR_SHA="${AWS_OFI_NCCL_PR_SHA:-c2e773dfb2c75b765b3415f8ffd1b47e7c239a7b}"  # IMMUTABLE PR#1351 head (a bare refs/pull/N/head is a moving ref)
-# DeepEP source divergence from the canonical setup_deepep_gin.sh (deepep-v2-benchmark): the canonical
-# pins the amazon-contributing/DeepEP fork; this sample pins deepseek-ai/DeepEP@b306af06 + PR#612 — the
-# substrate the shipped H200 (sm_90) numbers were measured on. The cost is Blackwell-only: the fork
-# carries the st.bulk 64-bit-operand fix (amazon-contributing/DeepEP#3, merged 2026-08-24) that makes
-# CUDA 13.0 codegen work on p6/Blackwell; this pin does not, so the manifest's DEEPEP_ARCH_LIST=10.x
-# knobs are documented-not-verified (README "Known limitations"). To enable Blackwell, set
-# DEEPEP_REPO=https://github.com/amazon-contributing/DeepEP.git + a fork SHA and re-verify on p6.
-DEEPEP_REPO="${DEEPEP_REPO:-https://github.com/deepseek-ai/DeepEP.git}"
-DEEPEP_SHA="${DEEPEP_SHA:-b306af06afd412c88e51e71802951606e40b7358}"            # measured substrate base (H200 sm_90)
-DEEPEP_PR="${DEEPEP_PR:-612}"                                                    # EFA auto-QP cap
-DEEPEP_PR_SHA="${DEEPEP_PR_SHA:-28d1f7fb173f728be51632ce0026fea23243e350}"       # IMMUTABLE PR#612 head (moving-ref trap)
+# DeepEP source = the amazon-contributing fork, same as the canonical setup_deepep_gin.sh
+# (deepep-v2-benchmark), which pins this fork and states "the benchmark supports no other
+# source". The fork carries the in-tree successors of deepseek PR#612's EFA work — the QP
+# count clamps into [_C.min_unordered_gin_qps, _C.max_unordered_gin_qps] (elastic.py) and the
+# RDMA link rate is probed from sysfs (envs.py _get_sysfs_rdma_gbs) — plus the Blackwell
+# st.bulk 64-bit-operand fix (e3fd4361), so no EP_EFA_MAX_QPS/EP_EFA_RDMA_GBS env exists here.
+DEEPEP_REPO="${DEEPEP_REPO:-https://github.com/amazon-contributing/DeepEP.git}"
+DEEPEP_SHA="${DEEPEP_SHA:-97d8f9bcc1be31e9036db2ab591ef9b9f4e38619}"            # amazon-contributing/DeepEP@main, 2026-09-03
 
 echo "== aws-ofi-nccl GIN @ ${AWS_OFI_NCCL_SHA} + PR#${AWS_OFI_NCCL_PR} =="
 git clone "${AWS_OFI_NCCL_REPO}" /opt/aws-ofi-nccl-src
@@ -51,14 +48,13 @@ test -f /opt/aws-ofi-nccl/lib/libnccl-net-ofi.so
 ldconfig
 cd /; rm -rf /opt/aws-ofi-nccl-src
 
-echo "== DeepEP-V2 source @ ${DEEPEP_SHA} + PR#${DEEPEP_PR} (@ ${DEEPEP_PR_SHA}) =="
+echo "== DeepEP-V2 source @ ${DEEPEP_SHA} (amazon-contributing fork) =="
 git clone "${DEEPEP_REPO}" /opt/DeepEP
 cd /opt/DeepEP
-git config user.email build@local; git config user.name build
 git fetch origin "${DEEPEP_SHA}"; git checkout "${DEEPEP_SHA}"
-git fetch origin "${DEEPEP_PR_SHA}"
-git merge --no-edit "${DEEPEP_PR_SHA}"                       # pin the IMMUTABLE PR head, not the moving ref
+# third-party/fmt is a submodule setup.py's include_dirs assumes; without it the build only
+# holds while torch keeps vendoring a compatible fmt under torch/include. Same step (and
+# reason) as the canonical setup_deepep_gin.sh.
+git submodule update --init --recursive
 git rev-parse HEAD > /opt/deepep.effective.sha
-test -f /opt/DeepEP/tests/elastic/test_ep.py
-test -f /opt/DeepEP/csrc/elastic/buffer.hpp
 echo "== setup_deepep_v2_efa.sh complete; DeepEP _C.so builds in-pod via recipe/build_deepep.sh =="

--- a/examples/inference/nvidia-dynamo/deepep-v2-efa/setup_deepep_v2_efa.sh
+++ b/examples/inference/nvidia-dynamo/deepep-v2-efa/setup_deepep_v2_efa.sh
@@ -10,11 +10,19 @@
 # (recipe/build_deepep.sh) because it needs a live CUDA context the build sandbox lacks.
 set -euo pipefail
 
-# ---- pins (every one justified; no 'latest'; a bare refs/pull/N/head is a MOVING ref) ----
+# ---- pins (released tag + immutable SHA; no 'latest') ----
+# v1.21.1 is the released aws-ofi-nccl tag that carries the CPU-proxy GIN op-tables this
+# sample uses (src/rdma/gin/nccl_ofi_gin_api.cpp exports ncclGinPlugin_v11 + _v13; only
+# _v14 is EFA-GDA-specific, which we do not use), and it is the aws-ofi-nccl version the
+# canonical micro-benchmarks/expert-parallelism/deepep-v2-benchmark runs on (bundled by
+# EFA installer 1.50.0) — known-good in this repo. Built from source here so gdrcopy
+# support is compiled in BY CONSTRUCTION (asserted below) and the plugin version stays
+# pinned independently of the installer. The plugin vendors its own GIN headers
+# (3rd-party/nccl/cuda/include/nccl/gin_v13.h), so its GIN interface is not coupled to
+# the pip NCCL headers — which is why no --with-nccl-headers flag is needed (and why
+# that flag, not being an AC_ARG_WITH this project defines, was silently ignored before).
 AWS_OFI_NCCL_REPO="${AWS_OFI_NCCL_REPO:-https://github.com/aws/aws-ofi-nccl.git}"
-AWS_OFI_NCCL_SHA="${AWS_OFI_NCCL_SHA:-9c44d34476f90ddbf4a12d0ac4fc412d46bd8ab4}"  # GIN plugin, gdrdrv-2.4 v1-fallback baked
-AWS_OFI_NCCL_PR="${AWS_OFI_NCCL_PR:-1351}"                                       # OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY param
-AWS_OFI_NCCL_PR_SHA="${AWS_OFI_NCCL_PR_SHA:-c2e773dfb2c75b765b3415f8ffd1b47e7c239a7b}"  # IMMUTABLE PR#1351 head (a bare refs/pull/N/head is a moving ref)
+AWS_OFI_NCCL_REF="${AWS_OFI_NCCL_REF:-v1.21.1}"
 # DeepEP source = the amazon-contributing fork, same as the canonical setup_deepep_gin.sh
 # (deepep-v2-benchmark), which pins this fork and states "the benchmark supports no other
 # source". The fork carries the in-tree successors of deepseek PR#612's EFA work — the QP
@@ -24,20 +32,18 @@ AWS_OFI_NCCL_PR_SHA="${AWS_OFI_NCCL_PR_SHA:-c2e773dfb2c75b765b3415f8ffd1b47e7c23
 DEEPEP_REPO="${DEEPEP_REPO:-https://github.com/amazon-contributing/DeepEP.git}"
 DEEPEP_SHA="${DEEPEP_SHA:-97d8f9bcc1be31e9036db2ab591ef9b9f4e38619}"            # amazon-contributing/DeepEP@main, 2026-09-03
 
-echo "== aws-ofi-nccl GIN @ ${AWS_OFI_NCCL_SHA} + PR#${AWS_OFI_NCCL_PR} =="
-git clone "${AWS_OFI_NCCL_REPO}" /opt/aws-ofi-nccl-src
+echo "== aws-ofi-nccl GIN @ ${AWS_OFI_NCCL_REF} =="
+git clone --depth 1 --branch "${AWS_OFI_NCCL_REF}" "${AWS_OFI_NCCL_REPO}" /opt/aws-ofi-nccl-src
 cd /opt/aws-ofi-nccl-src
-git config user.email build@local; git config user.name build
-git fetch origin "${AWS_OFI_NCCL_SHA}"; git checkout "${AWS_OFI_NCCL_SHA}"
-grep -q FALLBACK_V1_FOR_GDRDRV_24 src/nccl_ofi_gdrcopy.cpp   # assert the v1-fallback is present (fail-loud)
-if [ -n "${AWS_OFI_NCCL_PR_SHA}" ]; then
-  git fetch origin "${AWS_OFI_NCCL_PR_SHA}"
-  git cherry-pick "${AWS_OFI_NCCL_PR_SHA}"
-  grep -q GDRCOPY_FORCED_PCIE_COPY include/nccl_ofi_param.h  # assert the param landed (fail-loud)
-fi
+git rev-parse HEAD > /opt/aws-ofi-nccl.effective.sha
 ./autogen.sh
+# Released v1.21.1 already attempts gdr_pin_buffer_v2 with GDR_PIN_FLAG_FORCE_PCIE and falls
+# back to flags=0 on failure — the forced-PCIe attempt is the default and needs no env
+# override. The gdrdrv-2.4 workaround the old dev-line pin carried (a cherry-pick of the
+# closed-unmerged aws-ofi-nccl#1351) is gone; gdrdrv >= 2.5 on the compute nodes is a host
+# precondition instead (see README Prerequisites).
 ./configure --prefix=/opt/aws-ofi-nccl --with-libfabric=/opt/amazon/efa --with-cuda=/usr/local/cuda \
-  --with-nccl-headers="$(python3 -c 'import nvidia.nccl; print(nvidia.nccl.__path__[0])')/include" \
+  --with-gdrcopy=/usr/local \
   --enable-cudart-dynamic --enable-platform-aws
 make -C src -j"$(nproc)"; make -C src install
 test -f /opt/aws-ofi-nccl/lib/libnccl-net-ofi.so


### PR DESCRIPTION
## What this adds

A new self-contained inference example: **NVIDIA Dynamo** (`dynamo.frontend` OpenAI ingress +
`dynamo.vllm` engine) serving a Mixture-of-Experts model with **DeepEP-V2** (`ElasticBuffer`)
expert-parallel all-to-all, routed over **AWS EFA** via the NCCL-GIN **CPU-proxy** path
(`NCCL_GIN_TYPE=2`), on `p5en.48xlarge` (H200).

Path: `examples/inference/nvidia-dynamo/deepep-v2-efa/`

It is the Dynamo-frontend counterpart to the vLLM DeepEP-V2 sample (`examples/inference/vllm/deepep-v2-efa/`,
open in #1230). `dynamo.vllm` wraps the same vLLM engine — it forwards every unknown CLI flag straight into
vLLM's `AsyncEngineArgs` — so **nothing about the DeepEP-V2 / EFA transport changes**; this sample adds only
an OpenAI-compatible frontend and a DP/EP-aware worker wrapper on top of that proven substrate.

## Why this is not duplicating an existing PR

- **Not the other DeepEP-family PRs.** The open DeepEP-EFA family covers different serving engines:
  #1230 (vLLM), #1231 (vLLM + UCCL/NIXL), #1240 (TRT-LLM), #1242 (NeMo-RL). None serves the DeepEP-V2/EFA
  engine behind an **NVIDIA Dynamo** front. This is the Dynamo member of that family.
- **Not the existing `nvidia-dynamo/` platform sample.** The current `examples/inference/nvidia-dynamo/`
  folder is a SageMaker HyperPod-EKS deployment driven by the Dynamo **operator** and its
  `DynamoGraphDeployment` (DGD) CRD, serving GPT-OSS / Qwen3.6 in aggregated + disaggregated (NIXL)
  flavors on `ml.g6e.4xlarge`. That is a materially different execution model (operator + CRD + etcd/NATS
  platform, L40S, KV-transfer disagg) from this sample's raw two-node DeepEP-V2 MoE all-to-all serving on
  p5en/H200. See the "extend-before-create" note below.
- Duplicate-work checks (AGENTS.md §1) run clean: no open PR adds a Dynamo DeepEP-V2/EFA example.

## Extend-before-create (AGENTS.md §2)

Closest existing sibling: **`examples/inference/nvidia-dynamo/`** (matheus's Dynamo-platform sample).
This new content is placed as a **variant subdirectory inside it** (`nvidia-dynamo/deepep-v2-efa/`), not as
a parallel top-level sibling — so it extends the existing `nvidia-dynamo/` engine folder rather than
creating a new one.

A new *subdirectory* (rather than a README section or model recipe inside the platform sample) is justified
because the **execution model differs materially** from the platform sample:

| | `nvidia-dynamo/` (existing) | `nvidia-dynamo/deepep-v2-efa/` (this PR) |
|---|---|---|
| Orchestration | Dynamo operator + DGD CRD + etcd/NATS platform (Helm) | raw 2-node StatefulSet; **file** discovery backend; no operator/etcd/NATS |
| Cross-node fan-out | operator-wired discovery | vLLM's native DP coordinator (`--headless`, `--data-parallel-address`) over EFA |
| MoE transport | (agg / NIXL-disagg KV transfer) | **DeepEP-V2 `ElasticBuffer` expert all-to-all over EFA (NCCL-GIN CPU-proxy)** |
| Hardware | `ml.g6e.4xlarge` (L40S 48GB) | `p5en.48xlarge` (H200), 16 EFA NICs/node |

The two share the same *engine name* (`nvidia-dynamo`) — which is why this lives under that folder — but
not the same dependencies or run path, which is the AGENTS.md test for a new variant subdirectory.

## How it works (one paragraph)

DeepEP's default transport is NVSHMEM/IBGDA, which EFA does not provide. The V2 (`ElasticBuffer`) path runs
its dispatch/combine over `aws-ofi-nccl`'s GIN CPU-proxy (`NCCL_GIN_TYPE=2`, `OFI_NCCL_GIN_GDAKI=0`) on the
`efa-direct` fabric. Three things make it work: `EP_REUSE_NCCL_COMM=0` (or serve init segfaults — torch's
NCCL comm is lazy/null under vLLM before `ElasticBuffer` construction); the gdrcopy forced-PCIe capability
for the GIN plugin on gdrdrv-2.4 hosts (`OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1`, the parameter from
aws/aws-ofi-nccl#1351, cherry-picked at a pinned SHA); and DeepEP-V2 source pinned to `b306af06` + PR#612
(EFA auto-QP cap) at its immutable head SHA. Full detail + the eager/non-eager status table are in the folder
README. NGC-from-scratch: the Dockerfile is `FROM nvcr.io/nvidia/cuda:13.0.0-devel-ubuntu22.04`, all deps
built from public source; no private image is referenced anywhere.

The one Dynamo-specific delta beyond the vLLM substrate is a readiness contract documented in the README
("Readiness on Dynamo — why `/health` alone lies"): `dynamo.frontend`'s `/health` returns 200 as soon as the
HTTP server binds (its `ServiceObserver` defaults to Ready and nothing flips it on engine registration), so
the Kubernetes leader probe requires `/health` 200 **and** a populated `endpoints` array — otherwise the
probe would pass hours before the model finishes loading and defeat the startup budget.

## Test Results

**Cluster:** Amazon EKS, 2× `p5en.48xlarge` (H200, 8 GPU + 16 EFA NIC/node), EFA K8s device plugin,
`ap-southeast-3`.
**Model:** `Qwen/Qwen3-30B-A3B-FP8` (public), **DP16 / EP16**, `--enforce-eager` (the shipped default).
**Image:** NGC-from-scratch, built from the in-tree `Dockerfile`
(`FROM nvcr.io/nvidia/cuda:13.0.0-devel-ubuntu22.04`); vLLM pinned to the DeepEP-V2-backend merge commit
`e2f993dc4` (0.22.1rc1.dev283) + `ai-dynamo{,-runtime}==1.3.1`. Run 2026-09-04.

### 1. EFA transport proof, before model load

`recipe/run-kernel-test.sh` on both nodes runs `DeepEP/tests/elastic/test_ep.py` (DeepEP-V2 dispatch +
combine) and prints `KERNEL-TEST PASS` only when the `NCCL_DEBUG=INFO` log shows the `efa-direct` banner,
so a green result cannot be a silent TCP/SHM fallback:

```
--- LEADER (node_rank=0) ---
KERNEL-TEST PASS (node_rank=0) — DeepEP-V2 dispatch/combine over EFA verified
dynamo-deepep-v2-0 NCCL INFO NET/OFI Selected provider is efa, fabric is efa-direct (found 16 nics)

--- WORKER (node_rank=1) ---
KERNEL-TEST PASS (node_rank=1) — DeepEP-V2 dispatch/combine over EFA verified
dynamo-deepep-v2-1 NCCL INFO NET/OFI Selected provider is efa, fabric is efa-direct (found 16 nics)
```

(This gate exercises DeepEP + aws-ofi-nccl + EFA only — not vLLM or Dynamo — so it was captured on an image
whose transport layers, Dockerfile Layers 1–4, are byte-identical to the shipped image; only the vLLM/Dynamo
layers above them differ. The serve-path proof on the shipped image is §3.)

### 2. End-to-end serving — both pods Ready, coherent chat completion

Two-node StatefulSet (`kubernetes/`). The leader turns Ready only after `/health` carries a populated
`endpoints` array (post-weight-load engine registration — see README "why `/health` alone lies"):

```
$ kubectl -n dynamo-deepep get pods -o wide
NAME                 READY   STATUS    RESTARTS      AGE   NODE
dynamo-deepep-v2-0   1/1     Running   0             23m   ip-10-240-84-22    (leader)
dynamo-deepep-v2-1   1/1     Running   1 (15m ago)   23m   ip-10-240-79-100   (worker)
#   worker RESTARTS=1: HF anonymous-pull rate limit (HTTP 429) on one shard while both pods pulled
#   ~30 GB in parallel; recovered on retry from the per-pod cache (see kubernetes/ manifest note).

$ kubectl -n dynamo-deepep exec dynamo-deepep-v2-0 -- curl -s http://127.0.0.1:8000/health
{"status":"healthy",
 "endpoints":["dyn://dynamo.backend.clear_kv_blocks","dyn://dynamo.backend.generate",
              "dyn://dynamo.backend.get_perf_metrics"],
 "instances":[{"component":"backend","endpoint":"generate","namespace":"dynamo", ...}]}
```

The vLLM engine came up as the pinned DeepEP-V2 substrate across all 16 DP ranks with no CUDA launch fault
(the exact failure mode that ruled out the vLLM 0.26 line on this DeepEP/EFA substrate — see README
"eager vs non-eager"):

```
Initializing a V1 LLM engine (v0.22.1rc1.dev283+ge2f993dc4) with ... data_parallel_size=16,
  enforce_eager=True, quantization=fp8
GPU KV cache size: 1,015,152 tokens
INFO utils.launch_core_engines: Started DP Coordinator process (PID: 2507)
INFO coordinator.py:249 All engine subscriptions received by DP coordinator
init engine (profile, create kv cache, warmup model) took 226.42 s
```

Chat completion via the leader's OpenAI endpoint:

```
$ curl -s http://127.0.0.1:8000/v1/chat/completions -H 'content-type: application/json' -d \
  '{"model":"Qwen/Qwen3-30B-A3B-FP8","max_tokens":96,"temperature":0,
    "messages":[{"role":"user",
      "content":"In one sentence, what is expert parallelism in a Mixture-of-Experts model?"}]}'
{"id":"chatcmpl-306c1629-8779-48e8-9641-1eb13b8a3566","model":"Qwen/Qwen3-30B-A3B-FP8",
 "object":"chat.completion",
 "choices":[{"index":0,"finish_reason":"length","message":{"role":"assistant","content":
   "<think>\nOkay, the user is asking for a one-sentence definition of expert parallelism in a
    Mixture-of-Experts (MoE) model. Let me start by recalling what I know about MoE models. \n\nMoE
    models are a type of neural network architecture where multiple \"experts\" (sub-networks) are
    used, and a gating mechanism decides which experts to activate for each input. Now, expert
    parallelism... I think this refers to how the experts"}}],
 "usage":{"prompt_tokens":26,"completion_tokens":96,"total_tokens":122}}
```

### 3. EFA carried the expert all-to-all during serving

On this cluster's EFA kernel driver (3.3.0g) the `rdma_*_bytes` `hw_counters` sysfs node is not exposed
(`/sys/class/infiniband/rdmap*/ports/1/hw_counters/` is absent even though all 16 `rdmap*` devices
enumerate under `ibv_devices`), so a per-request byte delta cannot be read on this host. The serve-path
proof instead is that DeepEP-V2 brought its expert all-to-all up on EFA on **all 16 DP ranks across both
nodes** — the per-rank banner printed during engine init, under `--all2all-backend deepep_v2`,
`NCCL_GIN_TYPE=2`, `FI_PROVIDER=efa`:

```
(Worker_DP0_EP0  ...) [DeepEP] EFA detected: capping num_allocated_qps 129 -> 2 ...   # leader node, DP0–DP7
   ... DP1_EP1 … DP7_EP7 identical ...
(Worker_DP8_EP8  ...) [DeepEP] EFA detected: capping num_allocated_qps 129 -> 2 ...   # worker node, DP8–DP15
   ... DP9_EP9 … DP15_EP15 identical ...
```

All 16 ranks (DP0–7 on the leader node, DP8–15 on the worker node) initialized the DeepEP-V2 EFA path;
combined with the kernel-test `efa-direct (found 16 nics)` banner in §1, the expert traffic is on EFA, not a
TCP/SHM fallback.

> Provenance note: the `benchmarks/` tables in the folder are the vLLM twin's numbers measured at this same
> pin (`e2f993dc4`); they are carried as historical reference and are **not** re-measured on this Dynamo
> image. This PR's verification is the functional E2E above (transport proof + coherent completion under the
> Dynamo front), not a re-measured throughput table — stated honestly per the folder README's "Known
> limitations".

## Checklist

- [x] New example is self-contained (own README, pinned versions, no `latest` tags).
- [x] NGC-from-scratch Dockerfile (`FROM nvcr.io/nvidia/*`); no private image referenced.
- [x] `npx markdownlint-cli2` clean on changed markdown.
- [x] Extend-before-create justified (closest sibling named; execution model differs).
- [x] `## Test Results` filled with real E2E output on 2× p5en (DP16/EP16, coherent completion, EFA verified).


---

## Review round 1 — description updates (2026-09-07)

> **Merge order:** this PR depends on
> [#1230](https://github.com/awslabs/awsome-distributed-ai/pull/1230) (the sibling vLLM DeepEP-V2
> sample) landing first — the README's `../../vllm/deepep-v2-efa` relative links and the
> byte-identity claims resolve against that folder. The README also now states this and names the
> sibling in prose via the PR link, so the text stays valid either way.
>
> **Benchmarks provenance (review round 1):** the `benchmarks/` tables are now explicitly labeled
> as measured on the sibling vLLM sample's image with an earlier probe revision — not re-measured
> on this Dynamo image. A re-measure of this image on the updated recipe (amazon-contributing
> DeepEP fork + aws-ofi-nccl v1.21.1) is queued as the follow-up that re-attaches measured numbers
> to this sample.
