### PR TITLE
feat(pcs): targeted ODCR support and P4d/P4de compute node group template

### DIFF
--- a/.github/template-publish-manifest.yml
+++ b/.github/template-publish-manifest.yml
@@ -17,6 +17,8 @@ obsolete_keys: []
 entries:
   - source: architectures/aws-pcs/assets/add-cng.yaml
     key: aws-pcs/add-cng.yaml
+  - source: architectures/aws-pcs/assets/add-cng-p4d.yaml
+    key: aws-pcs/add-cng-p4d.yaml
   - source: architectures/aws-pcs/assets/add-cng-p5.yaml
     key: aws-pcs/add-cng-p5.yaml
   - source: architectures/aws-pcs/assets/add-cng-p6-b200.yaml

--- a/architectures/aws-pcs/README.md
+++ b/architectures/aws-pcs/README.md
@@ -132,7 +132,9 @@ complete reference see [PARAMETERS.md](./docs/PARAMETERS.md).
 |---|---|---|
 | `DeployPseriesCNG` | `false` | Deploy a multi-NIC GPU (P5/P6) queue |
 | `PseriesInstanceType` | `p5.48xlarge` | Picks the matching template + EFA NIC count automatically. See [GPU compute](#gpu-compute-p5p6) for the accepted types |
-| `CapacityReservationId` | *(empty)* | Capacity **Block** ID for the GPU queue; empty for On-Demand/ODCR |
+| `CapacityReservationId` | *(empty)* | Capacity reservation ID for the GPU queue; empty for plain On-Demand / "open" ODCR |
+| `CapacityReservationType` | `capacity-block` | `capacity-block` (default) or `targeted-odcr`. See [Capacity options](#gpu-compute-p5p6) |
+| `PseriesPlacementGroupName` | *(empty)* | Existing cluster placement group for the GPU queue; required with a placement-group-scoped ODCR |
 
 **5.1. Additional Cluster Configuration: Monitoring**
 
@@ -194,8 +196,9 @@ automatically.
 **Capacity options:**
 
 - **On-Demand**: leave `CapacityReservationId` empty.
-- **On-Demand Capacity Reservation (ODCR)**: also leave `CapacityReservationId` **empty** — create the ODCR with **"open"** instance matching and it is consumed automatically by the node group's On-Demand launches. (Do **not** put the ODCR ID in `CapacityReservationId`; that parameter forces Capacity-Block mode.)
-- **Capacity Blocks for ML**: set `CapacityReservationId` to the Capacity Block ID. The template then launches with `MarketType=capacity-block` against it.
+- **"Open" On-Demand Capacity Reservation (ODCR)**: also leave `CapacityReservationId` **empty** — an ODCR created with **"open"** instance matching is consumed automatically by the node group's On-Demand launches.
+- **Targeted ODCR, or any ODCR created inside a placement group**: set `CapacityReservationId` to the ODCR ID **and** `CapacityReservationType` to `targeted-odcr`. This keeps On-Demand billing and retains the cluster placement group. If the ODCR was created inside an existing placement group, also pass that group's name as `PseriesPlacementGroupName`: EC2 only matches an instance to such a reservation when the instance's **placement group ARN** matches the reservation's, alongside instance type, AZ, platform and tenancy ([Use Capacity Reservations with placement groups](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/cr-cpg.html)). Without it the node group creates its own group, the ARNs differ, and the launch silently falls through to unreserved On-Demand capacity.
+- **Capacity Blocks for ML**: set `CapacityReservationId` to the Capacity Block ID and leave `CapacityReservationType` at its `capacity-block` default. The template then launches with `MarketType=capacity-block` against it, with no placement group (Capacity Blocks carry their own physical placement).
 
 > **Capacity Block billing:** a block bills for its whole reserved window once it
 > starts and cannot be stopped early. When the block is active, run the GPU node
@@ -256,8 +259,10 @@ aws cloudformation create-stack \
 The `add-cng-p6-b300.yaml` template is selected automatically from `PseriesInstanceType`,
 and the EFA interface count is derived from the instance type — no interface-count
 parameter to set. For `p6-b200.48xlarge` or any P5 type, just change
-`PseriesInstanceType`. `CapacityReservationId` here is the **Capacity Block** ID; for
-On-Demand or an "open" ODCR, leave it empty (see [GPU compute](#gpu-compute-p5p6)).
+`PseriesInstanceType`. `CapacityReservationId` here defaults to being read as a
+**Capacity Block** ID; for a targeted ODCR set `CapacityReservationType=targeted-odcr`,
+and for On-Demand or an "open" ODCR leave it empty (see
+[GPU compute](#gpu-compute-p5p6)).
 
 ### Example 3: HPC EFA on the CPU queue (hpc7a)
 
@@ -707,8 +712,8 @@ parameter and default, see [PARAMETERS.md](./docs/PARAMETERS.md).
 | [`pcs-ready-dlami-with-enroot-pyxis.yaml`](./assets/pcs-ready-dlami-with-enroot-pyxis.yaml) | EC2 Image Builder: bake Enroot 3.5.0 + Pyxis 0.20.0 into the PCS-Ready DLAMI | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ready-dlami-with-enroot-pyxis.yaml&stackName=pcs-dlami) |
 
 `add-cng*` templates create a Slurm queue only when `QueueName` is set (leave it empty
-for login nodes). The P-series templates need a `CapacityReservationId` when using a
-Capacity Block.
+for login nodes). The P-series templates take a `CapacityReservationId` when using a
+Capacity Block or a targeted ODCR; `CapacityReservationType` selects which.
 
 ### Template nesting structure (deploy-all)
 

--- a/architectures/aws-pcs/README.md
+++ b/architectures/aws-pcs/README.md
@@ -131,9 +131,9 @@ complete reference see [PARAMETERS.md](./docs/PARAMETERS.md).
 | Parameter | Default | Purpose |
 |---|---|---|
 | `DeployPseriesCNG` | `false` | Deploy a multi-NIC GPU (P5/P6) queue |
-| `PseriesInstanceType` | `p5.48xlarge` | Picks the matching template + EFA NIC count automatically. See [GPU compute](#gpu-compute-p5p6) for the accepted types |
+| `PseriesInstanceType` | `p5.48xlarge` | Picks the matching template + EFA NIC count automatically. See [GPU compute](#gpu-compute-p4dp5p6) for the accepted types |
 | `CapacityReservationId` | *(empty)* | Capacity reservation ID for the GPU queue; empty for plain On-Demand / "open" ODCR |
-| `CapacityReservationType` | `capacity-block` | `capacity-block` (default) or `targeted-odcr`. See [Capacity options](#gpu-compute-p5p6) |
+| `CapacityReservationType` | `capacity-block` | `capacity-block` (default) or `targeted-odcr`. See [Capacity options](#gpu-compute-p4dp5p6) |
 | `PseriesPlacementGroupName` | *(empty)* | Existing cluster placement group for the GPU queue; required with a placement-group-scoped ODCR |
 
 **5.1. Additional Cluster Configuration: Monitoring**
@@ -178,7 +178,7 @@ idempotent — it no-ops on a pre-baked AMI.
 > Resolve once and pass the literal `ami-xxx` as `AmiId`. Details:
 > [OPERATIONS.md §2.5](./docs/OPERATIONS.md#25-ami-selection-amiid--pin-in-production).
 
-### GPU compute (P5/P6)
+### GPU compute (P4d/P5/P6)
 
 Different P-series instances expose different numbers of EFA interfaces, so each family
 has its own launch template with the right interface layout. With deploy-all you just
@@ -187,6 +187,8 @@ automatically.
 
 | Instance type | GPUs | EFA interfaces | Template |
 |---|---|---|---|
+| `p4d.24xlarge` | 8× A100 40GB | 4 | `add-cng-p4d.yaml` |
+| `p4de.24xlarge` | 8× A100 80GB | 4 | `add-cng-p4d.yaml` |
 | `p5.48xlarge` | 8× H100 | 32 | `add-cng-p5.yaml` |
 | `p5e.48xlarge` | 8× H200 | 32 | `add-cng-p5.yaml` |
 | `p5en.48xlarge` | 8× H200 | 16 | `add-cng-p5.yaml` |
@@ -262,7 +264,7 @@ parameter to set. For `p6-b200.48xlarge` or any P5 type, just change
 `PseriesInstanceType`. `CapacityReservationId` here defaults to being read as a
 **Capacity Block** ID; for a targeted ODCR set `CapacityReservationType=targeted-odcr`,
 and for On-Demand or an "open" ODCR leave it empty (see
-[GPU compute](#gpu-compute-p5p6)).
+[GPU compute](#gpu-compute-p4dp5p6)).
 
 ### Example 3: HPC EFA on the CPU queue (hpc7a)
 
@@ -707,7 +709,8 @@ parameter and default, see [PARAMETERS.md](./docs/PARAMETERS.md).
 | [`cluster.yaml`](./assets/cluster.yaml) | PCS cluster core (Slurm scheduler only, no nodes) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/cluster.yaml&stackName=pcs-cluster) |
 | [`add-cng.yaml`](./assets/add-cng.yaml) | Compute node group — login nodes, CPU / single-NIC-GPU queues (C6i, G5, G6); switches to a multi-NIC EFA `NetworkInterfaces` block when `EfaInterfaceCount > 0` (HPC types: hpc6a/hpc7a/hpc6id/hpc8a …) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/add-cng.yaml&stackName=pcs-add-cng) |
 | [`add-cng-p5.yaml`](./assets/add-cng-p5.yaml) | P5/P5e/P5en nodes (16/32 EFA interfaces, by type) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/add-cng-p5.yaml&stackName=pcs-add-cng-p5) |
-| [`add-cng-p6-b200.yaml`](./assets/add-cng-p6-b200.yaml) | P6-B200 nodes (8 EFA interfaces) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/add-cng-p6-b200.yaml&stackName=pcs-add-cng-p6-b200) |
+| [`add-cng-p4d.yaml`](./assets/add-cng-p4d.yaml) | P4d / P4de nodes (4 EFA interfaces) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/add-cng-p4d.yaml&stackName=pcs-add-cng-p4d) |
+| [`add-cng-p6-b200.yaml`](./assets/add-cng-p6-b200.yaml) | P6-B200 nodes (8 EFA interfaces) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/add-cng-p6-b200.yaml&stackName=pcs-add-cng-p4d) |
 | [`add-cng-p6-b300.yaml`](./assets/add-cng-p6-b300.yaml) | P6-B300 nodes (17 interfaces: 16 EFA + 1 ENA) | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/add-cng-p6-b300.yaml&stackName=pcs-add-cng-p6-b300) |
 | [`pcs-ready-dlami-with-enroot-pyxis.yaml`](./assets/pcs-ready-dlami-with-enroot-pyxis.yaml) | EC2 Image Builder: bake Enroot 3.5.0 + Pyxis 0.20.0 into the PCS-Ready DLAMI | [![Launch](images/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=https://awsome-distributed-ai.s3.amazonaws.com/templates/aws-pcs/pcs-ready-dlami-with-enroot-pyxis.yaml&stackName=pcs-dlami) |
 
@@ -746,7 +749,7 @@ pcs-ml-cluster-deploy-all.yaml                    ← user deploys this
 │          ├─ install-enroot-pyxis.sh (same as login)
 │          └─ install-monitoring.sh (nodeReady)
 │
-└─► add-cng-p5.yaml / add-cng-p6-b200.yaml       ← GPU queue (optional)
+└─► add-cng-p4d.yaml / add-cng-p5.yaml / add-cng-p6-b200.yaml / add-cng-p6-b300.yaml  ← GPU queue (optional)
     / add-cng-p6-b300.yaml
       • Multi-NIC EFA (16/32 cards, per-family)
       • MonitoringRole=compute → DCGM Exporter

--- a/architectures/aws-pcs/assets/add-cng-p4d.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p4d.yaml
@@ -1,0 +1,585 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# One add-cng template per GPU family by design: this file's NetworkInterfaces
+# block is hand-built for the p4d / p4de EFA layout (4 network cards, card 0 = EFA,
+# EFA cards on DeviceIndex 1; both types share it, per describe-instance-types
+# NetworkInfo.NetworkCards / EfaInfo.MaximumEfaInterfaces = 4). p5, p6-b200 and
+# p6-b300 differ enough in NIC topology that a single parameterized template would
+# be either unreadable or require a CAPABILITY_AUTO_EXPAND transform that breaks the
+# one-click quick-create links. See the rationale in add-cng-p5.yaml and the
+# consolidation item in docs/ROADMAP.md. InstanceType is locked with AllowedValues
+# to match this block.
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Adding Compute Node Group to PCS Cluster with multi-network interface (EFA) support for P4d / P4de (4 network cards; On-Demand, targeted ODCR or Capacity Block)
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Capacity Reservation Settings (Optional)
+        Parameters:
+          - CapacityReservationId
+          - CapacityReservationType
+          - PlacementGroupName
+      - Label:
+          default: Additional Compute Node Group Settings
+        Parameters:
+          - CngName
+          - QueueName
+          - InstanceType
+          - MaxCount
+          - MinCount
+      - Label:
+          default: PCS Cluster configuration
+        Parameters:
+          - ClusterId
+          - SubnetId
+          - AmiId
+          - ClusterSecurityGroupId
+          - IamProfileArn
+          - FSxLustreFilesystemId
+          - FSxLustreFilesystemMountName
+          - FSxOpenZFSFilesystemId
+      - Label:
+          default: Monitoring configuration
+        Parameters:
+          - DeployMonitoring
+          - MonitoringVersion
+          - MonitoringRepo
+          - MonitoringRole
+      - Label:
+          default: Container runtime (Enroot/Pyxis)
+        Parameters:
+          - InstallEnrootPyxis
+
+Parameters:
+  CapacityReservationId:
+    Type: String
+    Description: >-
+      (Optional) Capacity Block for ML reservation ID. When SET, the node group
+      launches with MarketType=capacity-block against this reservation. Leave
+      EMPTY for On-Demand. NOTE: this is for Capacity Blocks ONLY — do not put an
+      On-Demand Capacity Reservation (ODCR) ID here. An ODCR with "open" matching
+      is consumed automatically by On-Demand launches, so for ODCR leave this empty.
+    Default: ""
+
+  CapacityReservationType:
+    Type: String
+    Description: >-
+      How to interpret CapacityReservationId. 'capacity-block' (default,
+      backward compatible) launches with MarketType=capacity-block and does NOT
+      use a placement group, as Capacity Blocks already provide their own
+      physical placement. 'targeted-odcr' targets an On-Demand Capacity
+      Reservation that accepts only targeted launches, keeps On-Demand billing,
+      and KEEPS the cluster placement group -- required when the ODCR was
+      created inside a placement group, because EC2 only matches an instance to
+      such a reservation when the placement group ARN also matches. Ignored when
+      CapacityReservationId is empty.
+    Default: capacity-block
+    AllowedValues:
+      - capacity-block
+      - targeted-odcr
+
+  PlacementGroupName:
+    Type: String
+    Description: >-
+      (Optional) Name of an EXISTING cluster placement group to launch the
+      compute nodes into. Leave EMPTY (default) to create and use a new cluster
+      placement group. Set this when the capacity reservation you are consuming
+      was created inside a specific placement group -- the reservation is only
+      matched when the instance's placement group ARN matches the
+      reservation's. Only used on the On-Demand and 'targeted-odcr' paths;
+      Capacity Blocks do not use a placement group.
+    Default: ""
+
+  ClusterId:
+    Type: String
+    Description: Cluster ID (actual PCS cluster ID like pcs_xxxxx)
+
+  ClusterName:
+    Type: String
+    Description: User-friendly cluster name
+
+  CngName:
+    Type: String
+    Description: Name for Compute Node Group
+    Default: "gpu-p4d"
+
+  QueueName:
+    Type: String
+    Description: Name for Queue (leave empty to skip queue creation)
+    Default: ""
+
+  InstanceType:
+    Type: String
+    Description: >-
+      Instance type for the compute node group. Locked to p4d.24xlarge / p4de.24xlarge:
+      the NetworkInterfaces block below is hand-built for this family's EFA layout
+      (4 network cards, card 0 EFA), so a different type would launch with the
+      wrong NIC topology. Other GPU families have their own template
+      (add-cng-p5.yaml, add-cng-p6-b200.yaml, add-cng-p6-b300.yaml).
+    Default: "p4d.24xlarge"
+    AllowedValues:
+      - p4d.24xlarge
+      - p4de.24xlarge
+
+  RootVolumeSize:
+    Type: Number
+    Description: >-
+      Root EBS volume size (GiB) for compute nodes. The PCS-Ready DLAMI default (~75
+      GiB) is too small for pulling/importing large container images (Enroot/Pyxis
+      squashfs, Megatron ~20 GB). 300 GiB gives ample headroom.
+    Default: 300
+    MinValue: 75
+
+  MaxCount:
+    Type: Number
+    Description: Maximum number of instance
+
+  MinCount:
+    Type: Number
+    Description: Minimum number of instance. (it must be 0 if you want to use dynamic scaling)
+
+  SubnetId:
+    Type: AWS::EC2::Subnet::Id
+    Description: Select the Subnet where the Compute Node will be launched
+
+  AmiId:
+    Type: String
+    Description: >-
+      (Optional) AMI ID for the nodes. Leave empty to auto-resolve the latest
+      PCS-Ready DLAMI (Ubuntu 24.04 x86_64) from SSM Parameter Store. Set an explicit
+      ami-xxxx only to override (e.g. a custom AMI built with Enroot/Pyxis pre-baked).
+      The AMI must carry PCS agent >= 1.5.0-1 (PCS-Ready DLAMI builds since
+      2026-07-20 — see docs/PCS-READY-DLAMI.md): node setup runs through node
+      lifecycle actions, which older agents do not support.
+    Default: ""
+    AllowedPattern: '^$|^ami-[0-9a-f]{8,17}$'
+    ConstraintDescription: Must be empty or a valid AMI ID (ami-xxxxxxxxxxxxxxxxx)
+
+  ClusterSecurityGroupId:
+    Type: AWS::EC2::SecurityGroup::Id
+    Description: Select SecurityGroup for Compute Node Group for Cluster Communication
+
+  IamProfileArn:
+    Type: String
+    Description: IAM Instance Profile for Compute Node Group
+
+  FSxLustreFilesystemId:
+    Type: String
+    Description: Filesystem ID for FSx for Lustre
+    AllowedPattern: '^$|^fs-[0-9a-f]{8,17}$'
+    ConstraintDescription: Must be empty (no /fsx) or a valid FSx filesystem ID
+
+  FSxLustreFilesystemMountName:
+    Type: String
+    Description: MountName for FSx for Lustre
+
+  FSxOpenZFSFilesystemId:
+    Type: String
+    Description: Filesystem ID for FSx for OpenZFS
+    AllowedPattern: '^fs-[0-9a-f]{8,17}$'
+    ConstraintDescription: Must be a valid FSx filesystem ID (fs-xxxxxxxxxxxxxxxxx)
+
+  DeployMonitoring:
+    Type: String
+    Description: Deploy monitoring stack (Prometheus/Grafana on Login Node, DCGM exporter on Compute Node with GPU)
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+
+  MonitoringVersion:
+    Type: String
+    Description: >-
+      aws-parallelcluster-monitoring git ref to install (release tag or branch).
+      Used both to fetch post-install.sh from MonitoringRepo at this
+      ref and as the ref argument passed to it. Pin to a release tag for upstream
+      stability in production; a branch name (e.g. a fork's dev branch) can be
+      used together with MonitoringRepo for testing unreleased changes.
+    Default: 'v2.10.2'
+    AllowedPattern: '^[A-Za-z0-9._/-]+$'
+    ConstraintDescription: Must be a git ref (tag or branch)
+
+  MonitoringRepo:
+    Type: String
+    Description: >-
+      GitHub "owner/repo" to fetch the monitoring stack from. Override with a fork
+      together with a branch in MonitoringVersion to test unreleased changes before
+      they merge upstream.
+    Default: 'aws-samples/aws-parallelcluster-monitoring'
+    AllowedPattern: '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$'
+    ConstraintDescription: Must be a GitHub "owner/repo"
+
+  DcgmExporterImage:
+    Type: String
+    Description: >-
+      dcgm-exporter container image used by the monitoring stack on GPU nodes. The
+      default is a DCGM 4.5.2 build pinned by DIGEST -- this covers Hopper / B200 /
+      B300 alike (the digest pull bypasses the Docker 29.x OCI-index failure that
+      breaks newer NVCR tags). To pin to the older monitoring-default 4.2.0 (covers
+      Hopper + B200 only) or any other build, set this to that image reference
+      (preferably also a digest). No effect on CPU nodes.
+    Default: 'nvcr.io/nvidia/k8s/dcgm-exporter@sha256:a7ad6547d4546eaf4dd5d6b4c0b4db4101e63ef7dc3cdff7f42b767d2c60b706'
+
+  MonitoringRole:
+    Type: String
+    Description: Monitoring role for this node (login=head node with Prometheus/Grafana, compute=compute node with exporters, none=no monitoring)
+    Default: 'none'
+    AllowedValues:
+      - 'login'
+      - 'compute'
+      - 'none'
+
+  InstallEnrootPyxis:
+    Type: String
+    Description: >-
+      Install the Enroot/Pyxis container runtime at first boot (an
+      install-enroot-pyxis node lifecycle action running
+      scripts/install-enroot-pyxis.sh from the templates bucket). Set 'false'
+      when the runtime is pre-baked into AmiId, or when you don't need
+      containers. For any other first-boot customization, add your own script
+      to the compute node group's node lifecycle actions — PCS supports this
+      natively, so this template no longer proxies arbitrary scripts.
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+
+  SlurmVersion:
+    Type: String
+    Description: >-
+      The cluster's Slurm version, passed to the install-enroot-pyxis lifecycle
+      action so it can put the matching Slurm CLI bin on slurmd's PATH
+      (the Pyxis PMI hook needs scontrol). Must match the version the cluster was
+      created with.
+    Default: '25.11'
+    AllowedValues:
+      - '25.05'
+      - '25.11'
+
+  DirectoryDomainSuffix:
+    Type: String
+    Description: >-
+      LDAP domain suffix (e.g. dc=cluster,dc=internal). Only used when
+      DirectoryService != none.
+    Default: 'dc=cluster,dc=internal'
+
+  DirectoryRole:
+    Type: String
+    Description: >-
+      This CNG's role in the directory service. 'server' = install and run
+      the directory (slapd on login node). 'client' = configure SSSD to
+      resolve users from the directory server. 'none' = skip directory setup.
+      deploy-all sets this automatically (login=server, compute=client) when
+      DirectoryService != none.
+    Default: 'none'
+    AllowedValues:
+      - 'none'
+      - 'server'
+      - 'client'
+
+  S3BucketName:
+    Type: String
+    Description: S3 bucket where scripts are stored (same as nested templates bucket)
+    Default: 'awsome-distributed-ai'
+
+  S3KeyPrefix:
+    Type: String
+    Description: S3 key prefix for scripts (e.g. templates/aws-pcs/)
+    Default: 'templates/aws-pcs/'
+
+Conditions:
+  HasCapacityReservation: !Not [!Equals [!Ref CapacityReservationId, ""]]
+  # Capacity Block: reservation set AND type is capacity-block. Launches with
+  # MarketType=capacity-block and no placement group.
+  UseCapacityBlock: !And
+    - !Not [!Equals [!Ref CapacityReservationId, ""]]
+    - !Equals [!Ref CapacityReservationType, "capacity-block"]
+  # Targeted ODCR keeps On-Demand billing and the placement group; it is
+  # expressed by UsePlacementGroup below plus the absence of MarketType.
+  UsePlacementGroup: !Or
+    - !Equals [!Ref CapacityReservationId, ""]
+    - !Equals [!Ref CapacityReservationType, "targeted-odcr"]
+  CreatePlacementGroup: !And
+    - !Or
+      - !Equals [!Ref CapacityReservationId, ""]
+      - !Equals [!Ref CapacityReservationType, "targeted-odcr"]
+    - !Equals [!Ref PlacementGroupName, ""]
+  CreateQueue: !Not [!Equals [!Ref QueueName, ""]]
+  # Emit the monitoring-role tag for both login and compute nodes (any role
+  # other than 'none'). The monitoring stack identifies login nodes by this
+  # tag (monitoring-role=login) and excludes them from EC2 service discovery.
+  IsMonitoringRoleSet: !Not [!Equals [!Ref MonitoringRole, 'none']]
+  HasAmiId: !Not [!Equals [!Ref AmiId, ""]]
+  DirectoryEnabled: !Not [!Equals [!Ref DirectoryRole, 'none']]
+  HasLustre: !Not [!Equals [!Ref FSxLustreFilesystemId, '']]
+  EnrootPyxisEnabled: !Equals [!Ref InstallEnrootPyxis, 'true']
+  MonitoringEnabled: !Equals [!Ref DeployMonitoring, 'true']
+  HasDcgmImage: !Not [!Equals [!Ref DcgmExporterImage, '']]
+
+Resources:
+
+  # Cluster Placement Group (On-Demand only)
+  PlacementGroup:
+    Type: AWS::EC2::PlacementGroup
+    Condition: CreatePlacementGroup
+    Properties:
+      Strategy: cluster
+
+  # Compute Node groups - Compute Nodes
+  PCSNodeGroupCompute:
+    Type: AWS::PCS::ComputeNodeGroup
+    Properties:
+      ClusterId: !Ref ClusterId
+      Name: !Ref CngName
+      ScalingConfiguration:
+        MinInstanceCount: !Ref MinCount
+        MaxInstanceCount: !Ref MaxCount
+      IamInstanceProfileArn: !Ref IamProfileArn
+      CustomLaunchTemplate:
+        TemplateId: !Ref PCSLaunchTemplate
+        # Track the latest launch template version so template updates (e.g. NIC
+        # or UserData changes) actually reach the node group. Hardcoding Version: 1
+        # pins the node group to the original version and silently ignores updates.
+        Version: !GetAtt PCSLaunchTemplate.LatestVersionNumber
+      SubnetIds:
+        - !Ref SubnetId
+      AmiId: !If
+        - HasAmiId
+        - !Ref AmiId
+        - '{{resolve:ssm:/aws/service/pcs/ami/dlami-base-ubuntu2404/x86_64/latest/ami-id}}'
+      InstanceConfigs:
+        - InstanceType: !Ref InstanceType
+      PurchaseOption: !If [UseCapacityBlock, CAPACITY_BLOCK, !Ref "AWS::NoValue"]
+      # Node lifecycle actions (PCS agent >= 1.5.0-1; included in PCS-Ready
+      # DLAMI builds from 2026-07-20 — see docs/PCS-READY-DLAMI.md). Scripts
+      # run as root, in order, in the NodeBootstrapped stage: after PCS
+      # finishes node setup, BEFORE slurmd starts — the same ordering the
+      # cloud-init runcmd provided. The agent downloads each script itself
+      # (3 retries with backoff built in) and writes per-script logs to
+      # /var/log/amazon/pcs/lifecycle/actions/<stage>/<name>.log.
+      #
+      # Stage rationale:
+      # - needrestart-guard must be in place before the first apt run can
+      #   trigger a slurmd restart (kills jobs). CONTINUE: a missed guard
+      #   degrades protection but the node still works.
+      # - mounts must complete before slurmd starts, or the scheduler could
+      #   dispatch a job to a node without /home //fsx (nodeReady runs AFTER
+      #   the node is job-eligible). TERMINATE: a node without shared
+      #   storage is useless — replace it. EVERY_BOOT + idempotent scripts
+      #   cover reboots.
+      NodeLifecycleActions:
+        ScriptCachingPolicy: CACHE_ONCE
+        Stages:
+          NodeBootstrapped:
+            - Name: needrestart-guard
+              ScriptSource:
+                ScriptLocation: !Sub 's3://${S3BucketName}/${S3KeyPrefix}scripts/needrestart-guard.sh'
+              ExecutionPolicy: FIRST_BOOT_ONLY
+              OnError: CONTINUE
+            - Name: mount-openzfs-home
+              ScriptSource:
+                ScriptLocation: !Sub 's3://${S3BucketName}/${S3KeyPrefix}scripts/mount-openzfs-home.sh'
+              Arguments:
+                - !Ref FSxOpenZFSFilesystemId
+              ExecutionPolicy: EVERY_BOOT
+              OnError: TERMINATE
+            - !If
+              - HasLustre
+              - Name: mount-lustre-fsx
+                ScriptSource:
+                  ScriptLocation: !Sub 's3://${S3BucketName}/${S3KeyPrefix}scripts/mount-lustre-fsx.sh'
+                Arguments:
+                  - !Ref FSxLustreFilesystemId
+                  - !Ref FSxLustreFilesystemMountName
+                ExecutionPolicy: EVERY_BOOT
+                OnError: TERMINATE
+              - !Ref AWS::NoValue
+            # Directory setup must run AFTER mount-openzfs-home: the LDAP DB
+            # lives on shared /home/ldap-db (the script hard-fails if /home is
+            # not a mountpoint). CONTINUE preserves the log-and-continue
+            # invariant: Slurm launches jobs by numeric UID, so a failed
+            # directory client only degrades name resolution — and TERMINATE
+            # here would risk an endless replace loop.
+            - !If
+              - DirectoryEnabled
+              - Name: setup-directory
+                ScriptSource:
+                  ScriptLocation: !Sub 's3://${S3BucketName}/${S3KeyPrefix}scripts/setup-directory.sh'
+                Arguments:
+                  - !Ref DirectoryRole
+                  - !Ref DirectoryDomainSuffix
+                  - !Ref ClusterId
+                  - !Ref S3BucketName
+                  - !Ref S3KeyPrefix
+                ExecutionPolicy: FIRST_BOOT_ONLY
+                OnError: CONTINUE
+              - !Ref AWS::NoValue
+            # Enroot/Pyxis install runs last: it is the slowest step, and
+            # Pyxis is a Slurm SPANK plugin whose plugstack config must exist
+            # before slurmd starts — nodeBootstrapped guarantees that. The
+            # cluster's Slurm version goes in as the first argument (the node
+            # cannot discover it before slurmd exists). CONTINUE: a failed
+            # install only degrades container support — TERMINATE would risk
+            # a replace loop. The script is idempotent, so it is a fast no-op
+            # on an AMI with the runtime pre-baked.
+            - !If
+              - EnrootPyxisEnabled
+              - Name: install-enroot-pyxis
+                ScriptSource:
+                  ScriptLocation: !Sub 's3://${S3BucketName}/${S3KeyPrefix}scripts/install-enroot-pyxis.sh'
+                Arguments:
+                  - !Ref SlurmVersion
+                ExecutionPolicy: FIRST_BOOT_ONLY
+                OnError: CONTINUE
+              - !Ref AWS::NoValue
+          # Monitoring goes to nodeReady: it does not depend on slurmd order,
+          # and running it after registration keeps a multi-minute Docker
+          # install from delaying the node's availability.
+          NodeReady: !If
+            - MonitoringEnabled
+            - - Name: install-monitoring
+                ScriptSource:
+                  ScriptLocation: !Sub 's3://${S3BucketName}/${S3KeyPrefix}scripts/install-monitoring.sh'
+                Arguments: !If
+                  - HasDcgmImage
+                  - - !Ref MonitoringVersion
+                    - !Ref MonitoringRepo
+                    - !Ref DcgmExporterImage
+                  - - !Ref MonitoringVersion
+                    - !Ref MonitoringRepo
+                ExecutionPolicy: FIRST_BOOT_ONLY
+                OnError: CONTINUE
+            - !Ref AWS::NoValue
+
+  PCSQueueCompute:
+    Type: AWS::PCS::Queue
+    Condition: CreateQueue
+    Properties:
+      ClusterId: !Ref ClusterId
+      Name: !Ref QueueName
+      ComputeNodeGroupConfigurations:
+        - ComputeNodeGroupId: !GetAtt [PCSNodeGroupCompute, Id]
+
+  PCSLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: !Sub 'PCS-lt-${AWS::StackName}'
+
+      LaunchTemplateData:
+        InstanceType: !Ref InstanceType
+        BlockDeviceMappings:
+          - DeviceName: /dev/sda1
+            Ebs:
+              VolumeSize: !Ref RootVolumeSize
+              VolumeType: gp3
+              DeleteOnTermination: true
+        InstanceMarketOptions: !If
+          - UseCapacityBlock
+          - MarketType: capacity-block
+          - !Ref AWS::NoValue
+        CapacityReservationSpecification: !If
+          - HasCapacityReservation
+          - CapacityReservationTarget:
+              CapacityReservationId: !Ref CapacityReservationId
+          - !Ref AWS::NoValue
+        Placement: !If
+          - UsePlacementGroup
+          - GroupName: !If
+              - CreatePlacementGroup
+              - !Ref PlacementGroup
+              - !Ref PlacementGroupName
+          - !Ref AWS::NoValue
+        TagSpecifications:
+          - ResourceType: instance
+            Tags:
+              - Key: HPCRecipes
+                Value: "true"
+              # Name defaults to <ClusterName>-<CngName> so the EC2 console
+              # can tell instances of different clusters apart at a glance;
+              # retag freely, nothing operational reads it (monitoring keys
+              # off monitoring-role below, docs look up instances via the
+              # PCS API + aws:pcs:* tags).
+              - Key: Name
+                Value: !Sub '${ClusterName}-${CngName}'
+              - Key: CngName
+                Value: !Ref CngName
+              - Key: ClusterName
+                Value: !Ref ClusterName
+              - Key: pcs-cluster-id
+                Value: !Ref ClusterId
+              # Node type for the monitoring stack. Emitted for both login and
+              # compute (any role != none). Prometheus drops monitoring-role=login
+              # from EC2 SD (the static login_node job scrapes it); everything else
+              # is reported as instance_name=Compute. See aws-parallelcluster-monitoring
+              # prometheus-pcs.yml and issue #45.
+              - !If
+                - IsMonitoringRoleSet
+                - Key: monitoring-role
+                  Value: !Ref MonitoringRole
+                - !Ref AWS::NoValue
+              # Directory (multi-user) role tag, independent of monitoring-role.
+              # Emitted for both server (login) and client (compute) nodes when
+              # DirectoryRole != none. Compute clients discover the OpenLDAP
+              # server by querying for directory-role=server (NOT monitoring-role,
+              # which is owned by the monitoring stack). See setup-directory.sh.
+              - !If
+                - DirectoryEnabled
+                - Key: directory-role
+                  Value: !Ref DirectoryRole
+                - !Ref AWS::NoValue
+        MetadataOptions:
+          HttpEndpoint: enabled
+          HttpPutResponseHopLimit: 4
+          HttpTokens: required
+          InstanceMetadataTags: enabled
+        NetworkInterfaces:
+          # p4d / p4de support EFA on all 4 network cards (MaxEfaInterfaces=4),
+          # so every card uses InterfaceType: efa for maximum EFA bandwidth.
+          # Primary is network card 0, device index 0; the rest are device index 1.
+          # PCS requires InterfaceType: efa (not efa-only) to propagate correctly.
+          - Description: Primary network interface
+            DeviceIndex: 0
+            InterfaceType: efa
+            NetworkCardIndex: 0
+            SubnetId: !Ref SubnetId
+            Groups:
+            - !Ref ClusterSecurityGroupId
+          - DeviceIndex: 1
+            InterfaceType: efa
+            NetworkCardIndex: 1
+            SubnetId: !Ref SubnetId
+            Groups:
+            - !Ref ClusterSecurityGroupId
+          - DeviceIndex: 1
+            InterfaceType: efa
+            NetworkCardIndex: 2
+            SubnetId: !Ref SubnetId
+            Groups:
+            - !Ref ClusterSecurityGroupId
+          - DeviceIndex: 1
+            InterfaceType: efa
+            NetworkCardIndex: 3
+            SubnetId: !Ref SubnetId
+            Groups:
+            - !Ref ClusterSecurityGroupId
+Outputs:
+  NodeGroupId:
+    Description: Compute Node Group ID
+    Value: !GetAtt PCSNodeGroupCompute.Id
+  QueueId:
+    Condition: CreateQueue
+    Description: Queue ID
+    Value: !GetAtt PCSQueueCompute.Id
+  LaunchTemplateId:
+    Description: Launch template Id
+    Value: !Ref PCSLaunchTemplate
+  DefaultVersionNumber:
+    Description: Default version number
+    Value: !GetAtt PCSLaunchTemplate.DefaultVersionNumber
+  LatestVersionNumber:
+    Description: Latest version number
+    Value: !GetAtt PCSLaunchTemplate.DefaultVersionNumber

--- a/architectures/aws-pcs/assets/add-cng-p5.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p5.yaml
@@ -26,9 +26,11 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: Capacity Blocks for ML Settings (Optional)
+          default: Capacity Reservation Settings (Optional)
         Parameters:
           - CapacityReservationId
+          - CapacityReservationType
+          - PlacementGroupName
       - Label:
           default: Additional Compute Node Group Settings
         Parameters:
@@ -64,11 +66,43 @@ Parameters:
   CapacityReservationId:
     Type: String
     Description: >-
-      (Optional) Capacity Block for ML reservation ID. When SET, the node group
-      launches with MarketType=capacity-block against this reservation. Leave
-      EMPTY for On-Demand. NOTE: this is for Capacity Blocks ONLY — do not put an
-      On-Demand Capacity Reservation (ODCR) ID here. An ODCR with "open" matching
-      is consumed automatically by On-Demand launches, so for ODCR leave this empty.
+      (Optional) Capacity reservation ID for the node group. Interpreted
+      according to CapacityReservationType: for 'capacity-block' (default) this
+      is a Capacity Block for ML reservation ID and the node group launches with
+      MarketType=capacity-block; for 'targeted-odcr' this is an On-Demand
+      Capacity Reservation ID that the node group targets explicitly while
+      keeping On-Demand billing and the cluster placement group. Leave EMPTY for
+      plain On-Demand (an "open" ODCR with matching attributes is still consumed
+      automatically in that case).
+    Default: ""
+
+  CapacityReservationType:
+    Type: String
+    Description: >-
+      How to interpret CapacityReservationId. 'capacity-block' (default,
+      backward compatible) launches with MarketType=capacity-block and does NOT
+      use a placement group, as Capacity Blocks already provide their own
+      physical placement. 'targeted-odcr' targets an On-Demand Capacity
+      Reservation that accepts only targeted launches, keeps On-Demand billing,
+      and KEEPS the cluster placement group -- required when the ODCR was
+      created inside a placement group, because EC2 only matches an instance to
+      such a reservation when the placement group ARN also matches. Ignored when
+      CapacityReservationId is empty.
+    Default: capacity-block
+    AllowedValues:
+      - capacity-block
+      - targeted-odcr
+
+  PlacementGroupName:
+    Type: String
+    Description: >-
+      (Optional) Name of an EXISTING cluster placement group to launch the
+      compute nodes into. Leave EMPTY (default) to create and use a new cluster
+      placement group. Set this when the capacity reservation you are consuming
+      was created inside a specific placement group -- the reservation is only
+      matched when the instance's placement group ARN matches the
+      reservation's. Only used on the On-Demand and 'targeted-odcr' paths;
+      Capacity Blocks do not use a placement group.
     Default: ""
 
   ClusterId:
@@ -271,8 +305,29 @@ Conditions:
   # network cards, p5.48xlarge / p5e.48xlarge have 32. So "use 32 interfaces"
   # means "not p5en". No separate NetworkInterfaceCount parameter is needed.
   Use32Interfaces: !Not [!Equals [!Ref InstanceType, "p5en.48xlarge"]]
-  UseCapacityBlock: !Not [!Equals [!Ref CapacityReservationId, ""]]
-  UseOnDemand: !Equals [!Ref CapacityReservationId, ""]
+  HasCapacityReservation: !Not [!Equals [!Ref CapacityReservationId, ""]]
+  # Capacity Block: reservation set AND type is capacity-block. Launches with
+  # MarketType=capacity-block and no placement group.
+  UseCapacityBlock: !And
+    - !Not [!Equals [!Ref CapacityReservationId, ""]]
+    - !Equals [!Ref CapacityReservationType, "capacity-block"]
+  # Targeted ODCR: reservation set AND type is targeted-odcr. On-Demand billing,
+  # explicit reservation target, placement group RETAINED (EC2 only matches an
+  # instance to a reservation created in a placement group when the instance's
+  # placement group ARN matches too). Expressed via UsePlacementGroup below and
+  # by NOT setting MarketType/PurchaseOption, so no separate condition is needed.
+  # Both the plain On-Demand path and the targeted-ODCR path place instances in a
+  # cluster placement group.
+  UsePlacementGroup: !Or
+    - !Equals [!Ref CapacityReservationId, ""]
+    - !Equals [!Ref CapacityReservationType, "targeted-odcr"]
+  # Create our own placement group only when one is needed and the caller did not
+  # supply an existing one.
+  CreatePlacementGroup: !And
+    - !Or
+      - !Equals [!Ref CapacityReservationId, ""]
+      - !Equals [!Ref CapacityReservationType, "targeted-odcr"]
+    - !Equals [!Ref PlacementGroupName, ""]
   CreateQueue: !Not [!Equals [!Ref QueueName, ""]]
   # Emit the monitoring-role tag for both login and compute nodes (any role
   # other than 'none'). The monitoring stack identifies login nodes by this
@@ -287,10 +342,12 @@ Conditions:
 
 Resources:
 
-  # Cluster Placement Group (On-Demand only)
+  # Cluster Placement Group. Needed for the plain On-Demand path and for the
+  # targeted-ODCR path; skipped for Capacity Blocks (which carry their own
+  # placement) and when the caller passes an existing group via PlacementGroupName.
   PlacementGroup:
     Type: AWS::EC2::PlacementGroup
-    Condition: UseOnDemand
+    Condition: CreatePlacementGroup
     Properties:
       Strategy: cluster
 
@@ -446,14 +503,19 @@ Resources:
           - UseCapacityBlock
           - MarketType: capacity-block
           - !Ref AWS::NoValue
+        # Both reservation modes pin the reservation explicitly; only the
+        # Capacity Block path also sets MarketType above.
         CapacityReservationSpecification: !If
-          - UseCapacityBlock
+          - HasCapacityReservation
           - CapacityReservationTarget:
               CapacityReservationId: !Ref CapacityReservationId
           - !Ref AWS::NoValue
         Placement: !If
-          - UseOnDemand
-          - GroupName: !Ref PlacementGroup
+          - UsePlacementGroup
+          - GroupName: !If
+              - CreatePlacementGroup
+              - !Ref PlacementGroup
+              - !Ref PlacementGroupName
           - !Ref AWS::NoValue
         TagSpecifications:
           - ResourceType: instance

--- a/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b200.yaml
@@ -16,9 +16,11 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: Capacity Blocks for ML Settings (Optional)
+          default: Capacity Reservation Settings (Optional)
         Parameters:
           - CapacityReservationId
+          - CapacityReservationType
+          - PlacementGroupName
       - Label:
           default: Additional Compute Node Group Settings
         Parameters:
@@ -59,6 +61,35 @@ Parameters:
       EMPTY for On-Demand. NOTE: this is for Capacity Blocks ONLY — do not put an
       On-Demand Capacity Reservation (ODCR) ID here. An ODCR with "open" matching
       is consumed automatically by On-Demand launches, so for ODCR leave this empty.
+    Default: ""
+
+  CapacityReservationType:
+    Type: String
+    Description: >-
+      How to interpret CapacityReservationId. 'capacity-block' (default,
+      backward compatible) launches with MarketType=capacity-block and does NOT
+      use a placement group, as Capacity Blocks already provide their own
+      physical placement. 'targeted-odcr' targets an On-Demand Capacity
+      Reservation that accepts only targeted launches, keeps On-Demand billing,
+      and KEEPS the cluster placement group -- required when the ODCR was
+      created inside a placement group, because EC2 only matches an instance to
+      such a reservation when the placement group ARN also matches. Ignored when
+      CapacityReservationId is empty.
+    Default: capacity-block
+    AllowedValues:
+      - capacity-block
+      - targeted-odcr
+
+  PlacementGroupName:
+    Type: String
+    Description: >-
+      (Optional) Name of an EXISTING cluster placement group to launch the
+      compute nodes into. Leave EMPTY (default) to create and use a new cluster
+      placement group. Set this when the capacity reservation you are consuming
+      was created inside a specific placement group -- the reservation is only
+      matched when the instance's placement group ARN matches the
+      reservation's. Only used on the On-Demand and 'targeted-odcr' paths;
+      Capacity Blocks do not use a placement group.
     Default: ""
 
   ClusterId:
@@ -258,8 +289,22 @@ Parameters:
     Default: 'templates/aws-pcs/'
 
 Conditions:
-  UseCapacityBlock: !Not [!Equals [!Ref CapacityReservationId, ""]]
-  UseOnDemand: !Equals [!Ref CapacityReservationId, ""]
+  HasCapacityReservation: !Not [!Equals [!Ref CapacityReservationId, ""]]
+  # Capacity Block: reservation set AND type is capacity-block. Launches with
+  # MarketType=capacity-block and no placement group.
+  UseCapacityBlock: !And
+    - !Not [!Equals [!Ref CapacityReservationId, ""]]
+    - !Equals [!Ref CapacityReservationType, "capacity-block"]
+  # Targeted ODCR keeps On-Demand billing and the placement group; it is
+  # expressed by UsePlacementGroup below plus the absence of MarketType.
+  UsePlacementGroup: !Or
+    - !Equals [!Ref CapacityReservationId, ""]
+    - !Equals [!Ref CapacityReservationType, "targeted-odcr"]
+  CreatePlacementGroup: !And
+    - !Or
+      - !Equals [!Ref CapacityReservationId, ""]
+      - !Equals [!Ref CapacityReservationType, "targeted-odcr"]
+    - !Equals [!Ref PlacementGroupName, ""]
   CreateQueue: !Not [!Equals [!Ref QueueName, ""]]
   # Emit the monitoring-role tag for both login and compute nodes (any role
   # other than 'none'). The monitoring stack identifies login nodes by this
@@ -277,7 +322,7 @@ Resources:
   # Cluster Placement Group (On-Demand only)
   PlacementGroup:
     Type: AWS::EC2::PlacementGroup
-    Condition: UseOnDemand
+    Condition: CreatePlacementGroup
     Properties:
       Strategy: cluster
 
@@ -434,13 +479,16 @@ Resources:
           - MarketType: capacity-block
           - !Ref AWS::NoValue
         CapacityReservationSpecification: !If
-          - UseCapacityBlock
+          - HasCapacityReservation
           - CapacityReservationTarget:
               CapacityReservationId: !Ref CapacityReservationId
           - !Ref AWS::NoValue
         Placement: !If
-          - UseOnDemand
-          - GroupName: !Ref PlacementGroup
+          - UsePlacementGroup
+          - GroupName: !If
+              - CreatePlacementGroup
+              - !Ref PlacementGroup
+              - !Ref PlacementGroupName
           - !Ref AWS::NoValue
         TagSpecifications:
           - ResourceType: instance

--- a/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
+++ b/architectures/aws-pcs/assets/add-cng-p6-b300.yaml
@@ -18,9 +18,11 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: Capacity Blocks for ML Settings (Optional)
+          default: Capacity Reservation Settings (Optional)
         Parameters:
           - CapacityReservationId
+          - CapacityReservationType
+          - PlacementGroupName
       - Label:
           default: Additional Compute Node Group Settings
         Parameters:
@@ -61,6 +63,35 @@ Parameters:
       EMPTY for On-Demand. NOTE: this is for Capacity Blocks ONLY — do not put an
       On-Demand Capacity Reservation (ODCR) ID here. An ODCR with "open" matching
       is consumed automatically by On-Demand launches, so for ODCR leave this empty.
+    Default: ""
+
+  CapacityReservationType:
+    Type: String
+    Description: >-
+      How to interpret CapacityReservationId. 'capacity-block' (default,
+      backward compatible) launches with MarketType=capacity-block and does NOT
+      use a placement group, as Capacity Blocks already provide their own
+      physical placement. 'targeted-odcr' targets an On-Demand Capacity
+      Reservation that accepts only targeted launches, keeps On-Demand billing,
+      and KEEPS the cluster placement group -- required when the ODCR was
+      created inside a placement group, because EC2 only matches an instance to
+      such a reservation when the placement group ARN also matches. Ignored when
+      CapacityReservationId is empty.
+    Default: capacity-block
+    AllowedValues:
+      - capacity-block
+      - targeted-odcr
+
+  PlacementGroupName:
+    Type: String
+    Description: >-
+      (Optional) Name of an EXISTING cluster placement group to launch the
+      compute nodes into. Leave EMPTY (default) to create and use a new cluster
+      placement group. Set this when the capacity reservation you are consuming
+      was created inside a specific placement group -- the reservation is only
+      matched when the instance's placement group ARN matches the
+      reservation's. Only used on the On-Demand and 'targeted-odcr' paths;
+      Capacity Blocks do not use a placement group.
     Default: ""
 
   ClusterId:
@@ -261,8 +292,22 @@ Parameters:
     Default: 'templates/aws-pcs/'
 
 Conditions:
-  UseCapacityBlock: !Not [!Equals [!Ref CapacityReservationId, ""]]
-  UseOnDemand: !Equals [!Ref CapacityReservationId, ""]
+  HasCapacityReservation: !Not [!Equals [!Ref CapacityReservationId, ""]]
+  # Capacity Block: reservation set AND type is capacity-block. Launches with
+  # MarketType=capacity-block and no placement group.
+  UseCapacityBlock: !And
+    - !Not [!Equals [!Ref CapacityReservationId, ""]]
+    - !Equals [!Ref CapacityReservationType, "capacity-block"]
+  # Targeted ODCR keeps On-Demand billing and the placement group; it is
+  # expressed by UsePlacementGroup below plus the absence of MarketType.
+  UsePlacementGroup: !Or
+    - !Equals [!Ref CapacityReservationId, ""]
+    - !Equals [!Ref CapacityReservationType, "targeted-odcr"]
+  CreatePlacementGroup: !And
+    - !Or
+      - !Equals [!Ref CapacityReservationId, ""]
+      - !Equals [!Ref CapacityReservationType, "targeted-odcr"]
+    - !Equals [!Ref PlacementGroupName, ""]
   CreateQueue: !Not [!Equals [!Ref QueueName, ""]]
   # Emit the monitoring-role tag for both login and compute nodes (any role
   # other than 'none'). The monitoring stack identifies login nodes by this
@@ -280,7 +325,7 @@ Resources:
   # Cluster Placement Group (On-Demand only)
   PlacementGroup:
     Type: AWS::EC2::PlacementGroup
-    Condition: UseOnDemand
+    Condition: CreatePlacementGroup
     Properties:
       Strategy: cluster
 
@@ -437,13 +482,16 @@ Resources:
           - MarketType: capacity-block
           - !Ref AWS::NoValue
         CapacityReservationSpecification: !If
-          - UseCapacityBlock
+          - HasCapacityReservation
           - CapacityReservationTarget:
               CapacityReservationId: !Ref CapacityReservationId
           - !Ref AWS::NoValue
         Placement: !If
-          - UseOnDemand
-          - GroupName: !Ref PlacementGroup
+          - UsePlacementGroup
+          - GroupName: !If
+              - CreatePlacementGroup
+              - !Ref PlacementGroup
+              - !Ref PlacementGroupName
           - !Ref AWS::NoValue
         TagSpecifications:
           - ResourceType: instance

--- a/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
+++ b/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
@@ -48,6 +48,8 @@ Metadata:
           - PseriesMinCount
           - PseriesMaxCount
           - CapacityReservationId
+          - CapacityReservationType
+          - PseriesPlacementGroupName
           - PseriesCngName
           - PseriesQueueName
       - Label:
@@ -146,7 +148,11 @@ Metadata:
       PseriesMaxCount:
         default: "GPU queue max nodes"
       CapacityReservationId:
-        default: "Capacity Block for ML reservation ID (leave empty for On-Demand/ODCR)"
+        default: "Capacity reservation ID (empty = plain On-Demand)"
+      CapacityReservationType:
+        default: "Capacity reservation type (capacity-block or targeted-odcr)"
+      PseriesPlacementGroupName:
+        default: "GPU queue existing placement group name (empty = create new)"
       PseriesCngName:
         default: "GPU node group name"
       PseriesQueueName:
@@ -572,12 +578,37 @@ Parameters:
     Type: String
     Default: ""
     Description: >-
-      (Optional) **Capacity Block for ML reservation ID** for the GPU node group.
-      When SET, GPU nodes launch with MarketType=capacity-block against this
-      reservation. Leave EMPTY for On-Demand. This parameter is for Capacity
-      Blocks ONLY -- do NOT put an On-Demand Capacity Reservation (ODCR) ID here;
-      an "open" ODCR is consumed automatically by On-Demand launches, so for ODCR
-      leave this empty.
+      (Optional) Capacity reservation ID for the GPU node group, interpreted per
+      CapacityReservationType. With 'capacity-block' (default) this is a Capacity
+      Block for ML ID and GPU nodes launch with MarketType=capacity-block. With
+      'targeted-odcr' this is an On-Demand Capacity Reservation ID that the node
+      group targets explicitly, keeping On-Demand billing and the cluster
+      placement group. Leave EMPTY for plain On-Demand (an "open" ODCR with
+      matching attributes is consumed automatically in that case).
+
+  CapacityReservationType:
+    Type: String
+    Default: capacity-block
+    AllowedValues:
+      - capacity-block
+      - targeted-odcr
+    Description: >-
+      How to interpret CapacityReservationId for the GPU node group.
+      'capacity-block' (default, backward compatible) = Capacity Block for ML.
+      'targeted-odcr' = an ODCR that accepts only targeted launches; keeps
+      On-Demand billing and the placement group. Use 'targeted-odcr' together
+      with PseriesPlacementGroupName when the ODCR was created inside a
+      placement group, since EC2 only matches an instance to such a reservation
+      when the placement group ARN matches as well. Ignored when
+      CapacityReservationId is empty.
+
+  PseriesPlacementGroupName:
+    Type: String
+    Default: ""
+    Description: >-
+      (Optional) Name of an EXISTING cluster placement group for the GPU node
+      group. Empty (default) creates a new one. Set this when consuming a
+      capacity reservation that was created inside a specific placement group.
 
   RootVolumeSize:
     Type: Number
@@ -853,6 +884,8 @@ Resources:
         FSxLustreFilesystemMountName: !GetAtt PrerequisitesStack.Outputs.FSxLustreFilesystemMountname
         FSxOpenZFSFilesystemId: !GetAtt PrerequisitesStack.Outputs.FSxOFilesystemId
         CapacityReservationId: !Ref CapacityReservationId
+        CapacityReservationType: !Ref CapacityReservationType
+        PlacementGroupName: !Ref PseriesPlacementGroupName
         DeployMonitoring: !If [MonitoringEnabled, "true", "false"]
         MonitoringVersion: !Ref MonitoringVersion
         MonitoringRepo: !Ref MonitoringRepo
@@ -894,6 +927,8 @@ Resources:
         FSxLustreFilesystemMountName: !GetAtt PrerequisitesStack.Outputs.FSxLustreFilesystemMountname
         FSxOpenZFSFilesystemId: !GetAtt PrerequisitesStack.Outputs.FSxOFilesystemId
         CapacityReservationId: !Ref CapacityReservationId
+        CapacityReservationType: !Ref CapacityReservationType
+        PlacementGroupName: !Ref PseriesPlacementGroupName
         DeployMonitoring: !If [MonitoringEnabled, "true", "false"]
         MonitoringVersion: !Ref MonitoringVersion
         MonitoringRepo: !Ref MonitoringRepo
@@ -935,6 +970,8 @@ Resources:
         FSxLustreFilesystemMountName: !GetAtt PrerequisitesStack.Outputs.FSxLustreFilesystemMountname
         FSxOpenZFSFilesystemId: !GetAtt PrerequisitesStack.Outputs.FSxOFilesystemId
         CapacityReservationId: !Ref CapacityReservationId
+        CapacityReservationType: !Ref CapacityReservationType
+        PlacementGroupName: !Ref PseriesPlacementGroupName
         DeployMonitoring: !If [MonitoringEnabled, "true", "false"]
         MonitoringVersion: !Ref MonitoringVersion
         MonitoringRepo: !Ref MonitoringRepo

--- a/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
+++ b/architectures/aws-pcs/assets/pcs-ml-cluster-deploy-all.yaml
@@ -552,10 +552,13 @@ Parameters:
     Description: >-
       Instance type for the P-series compute node group. The right multi-NIC EFA
       template AND interface count are selected automatically from this value:
-      p5* use add-cng-p5.yaml (p5/p5e = 32 NICs, p5en = 16), p6-b200.48xlarge uses
-      add-cng-p6-b200.yaml (8 NICs), p6-b300.48xlarge uses add-cng-p6-b300.yaml (17 NICs).
+      p4d/p4de.24xlarge use add-cng-p4d.yaml (4 NICs), p5* use add-cng-p5.yaml
+      (p5/p5e = 32 NICs, p5en = 16), p6-b200.48xlarge uses add-cng-p6-b200.yaml
+      (8 NICs), p6-b300.48xlarge uses add-cng-p6-b300.yaml (17 NICs).
     Default: "p5.48xlarge"
     AllowedValues:
+      - p4d.24xlarge
+      - p4de.24xlarge
       - p5.48xlarge
       - p5e.48xlarge
       - p5en.48xlarge
@@ -677,8 +680,13 @@ Conditions:
     - !Condition GrafanaAccessEnabled
   MonitoringEnabled: !Not [!Equals [!Ref MonitoringStack, 'none']]
   # Select the right multi-NIC EFA template from the P-series instance type.
-  # p6-b200/p6-b300 have different network-card counts than P5, so each family
-  # gets its own nested stack; anything else falls back to the P5 template.
+  # p4d/p4de, p6-b200 and p6-b300 have different network-card counts than P5, so
+  # each family gets its own nested stack; anything else falls back to the P5 template.
+  PseriesIsP4D: !And
+    - !Condition DeployPseriesCNGEnabled
+    - !Or
+      - !Equals [!Ref PseriesInstanceType, 'p4d.24xlarge']
+      - !Equals [!Ref PseriesInstanceType, 'p4de.24xlarge']
   PseriesIsP6B200: !And
     - !Condition DeployPseriesCNGEnabled
     - !Equals [!Ref PseriesInstanceType, 'p6-b200.48xlarge']
@@ -687,6 +695,8 @@ Conditions:
     - !Equals [!Ref PseriesInstanceType, 'p6-b300.48xlarge']
   PseriesIsP5: !And
     - !Condition DeployPseriesCNGEnabled
+    - !Not [!Equals [!Ref PseriesInstanceType, 'p4d.24xlarge']]
+    - !Not [!Equals [!Ref PseriesInstanceType, 'p4de.24xlarge']]
     - !Not [!Equals [!Ref PseriesInstanceType, 'p6-b200.48xlarge']]
     - !Not [!Equals [!Ref PseriesInstanceType, 'p6-b300.48xlarge']]
 
@@ -953,6 +963,49 @@ Resources:
     DependsOn: ClusterStack
     Properties:
       TemplateURL: !Sub 'https://${S3BucketName}.s3.amazonaws.com/${S3KeyPrefix}add-cng-p6-b300.yaml'
+      Parameters:
+        ClusterId: !GetAtt ClusterStack.Outputs.ClusterId
+        ClusterName: !Sub '${AWS::StackName}'
+        CngName: !Ref PseriesCngName
+        QueueName: !Ref PseriesQueueName
+        InstanceType: !Ref PseriesInstanceType
+        RootVolumeSize: !Ref RootVolumeSize
+        MaxCount: !Ref PseriesMaxCount
+        MinCount: !Ref PseriesMinCount
+        SubnetId: !GetAtt PrerequisitesStack.Outputs.PrimaryPrivateSubnet
+        AmiId: !Ref AmiId
+        ClusterSecurityGroupId: !GetAtt PrerequisitesStack.Outputs.SecurityGroup
+        IamProfileArn: !GetAtt ClusterStack.Outputs.InstanceProfileArn
+        FSxLustreFilesystemId: !GetAtt PrerequisitesStack.Outputs.FSxLustreFilesystemId
+        FSxLustreFilesystemMountName: !GetAtt PrerequisitesStack.Outputs.FSxLustreFilesystemMountname
+        FSxOpenZFSFilesystemId: !GetAtt PrerequisitesStack.Outputs.FSxOFilesystemId
+        CapacityReservationId: !Ref CapacityReservationId
+        CapacityReservationType: !Ref CapacityReservationType
+        PlacementGroupName: !Ref PseriesPlacementGroupName
+        DeployMonitoring: !If [MonitoringEnabled, "true", "false"]
+        MonitoringVersion: !Ref MonitoringVersion
+        MonitoringRepo: !Ref MonitoringRepo
+        DcgmExporterImage: !Ref DcgmExporterImage
+        SlurmVersion: !Ref SlurmVersion
+        MonitoringRole: compute
+        InstallEnrootPyxis: !Ref InstallEnrootPyxis
+        DirectoryRole: !If [DirectoryEnabled, 'client', 'none']
+        DirectoryDomainSuffix: !Ref DirectoryDomainSuffix
+        S3BucketName: !Ref S3BucketName
+        S3KeyPrefix: !Ref S3KeyPrefix
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-PseriesCNG'
+
+  #############################################################################
+  # 6d. P4d / P4de Compute Node Group Stack (4 NICs, fixed)
+  #############################################################################
+  P4DCNGStack:
+    Type: AWS::CloudFormation::Stack
+    Condition: PseriesIsP4D
+    DependsOn: ClusterStack
+    Properties:
+      TemplateURL: !Sub 'https://${S3BucketName}.s3.amazonaws.com/${S3KeyPrefix}add-cng-p4d.yaml'
       Parameters:
         ClusterId: !GetAtt ClusterStack.Outputs.ClusterId
         ClusterName: !Sub '${AWS::StackName}'

--- a/architectures/aws-pcs/docs/PARAMETERS.md
+++ b/architectures/aws-pcs/docs/PARAMETERS.md
@@ -55,12 +55,12 @@ it directly.
 
 ## 4. GPU Compute Node Group — P5/P6 (Optional)
 
-See [GPU compute](../README.md#gpu-compute-p5p6) for instance/EFA/capacity guidance.
+See [GPU compute](../README.md#gpu-compute-p4dp5p6) for instance/EFA/capacity guidance.
 
 | Parameter | Default | Purpose |
 |---|---|---|
 | `DeployPseriesCNG` | `false` | Deploy a GPU (P5/P6) queue |
-| `PseriesInstanceType` | `p5.48xlarge` | GPU instance type; selects the matching multi-NIC template **and** EFA interface count automatically |
+| `PseriesInstanceType` | `p5.48xlarge` | GPU instance type (`p4d.24xlarge`, `p4de.24xlarge`, `p5.48xlarge`, `p5e.48xlarge`, `p5en.48xlarge`, `p6-b200.48xlarge`, `p6-b300.48xlarge`); selects the matching multi-NIC template **and** EFA interface count automatically |
 | `PseriesMinCount` | `0` | GPU queue minimum nodes |
 | `PseriesMaxCount` | `4` | GPU queue maximum nodes |
 | `CapacityReservationId` | *(empty)* | Capacity reservation ID for the GPU queue, interpreted per `CapacityReservationType`. Empty = plain On-Demand (an "open" ODCR with matching attributes is still consumed automatically) |

--- a/architectures/aws-pcs/docs/PARAMETERS.md
+++ b/architectures/aws-pcs/docs/PARAMETERS.md
@@ -63,7 +63,9 @@ See [GPU compute](../README.md#gpu-compute-p5p6) for instance/EFA/capacity guida
 | `PseriesInstanceType` | `p5.48xlarge` | GPU instance type; selects the matching multi-NIC template **and** EFA interface count automatically |
 | `PseriesMinCount` | `0` | GPU queue minimum nodes |
 | `PseriesMaxCount` | `4` | GPU queue maximum nodes |
-| `CapacityReservationId` | *(empty)* | Capacity **Block** reservation ID (sets `MarketType=capacity-block`). Leave empty for On-Demand / ODCR — **do not** put an ODCR ID here |
+| `CapacityReservationId` | *(empty)* | Capacity reservation ID for the GPU queue, interpreted per `CapacityReservationType`. Empty = plain On-Demand (an "open" ODCR with matching attributes is still consumed automatically) |
+| `CapacityReservationType` | `capacity-block` | How to read `CapacityReservationId`. `capacity-block` sets `MarketType=capacity-block` and uses no placement group. `targeted-odcr` targets an ODCR that accepts only targeted launches, keeps On-Demand billing, and **keeps** the placement group — required when the ODCR was created inside a placement group |
+| `PseriesPlacementGroupName` | *(empty)* | Name of an **existing** cluster placement group for the GPU queue. Empty creates a new one. Set it when the reservation you are consuming was created inside a specific placement group |
 | `PseriesCngName` | `gpu-p5` | GPU node-group name |
 | `PseriesQueueName` | `gpu-p5` | GPU Slurm queue name |
 

--- a/architectures/aws-pcs/docs/ROADMAP.md
+++ b/architectures/aws-pcs/docs/ROADMAP.md
@@ -14,21 +14,19 @@ Priority: 🔴 high · 🟡 medium · 🟢 low
   NAT gateway). This unblocks `OpenZFSDeploymentType=MULTI_AZ` and higher-availability
   layouts. *(Note: OpenZFS MULTI_AZ wiring of the 2nd subnet into the FSx resource is a
   follow-up; the subnets + routing are in place.)*
-- [ ] 🟡 **Targeted ODCR support for GPU node groups.** Today `CapacityReservationId`
-  on `add-cng-p5`/`add-cng-p6-b200`/`add-cng-p6-b300` is **Capacity Block for ML only** —
-  setting it forces `MarketType=capacity-block` and drops the placement group, so a
-  *targeted* On-Demand Capacity Reservation (ODCR) cannot be consumed (only "open" ODCRs,
-  via the empty/On-Demand path, work). Add a `CapacityReservationType` enum
-  (`none` | `capacity-block` | `targeted-odcr`) and branch the launch template:
-  `targeted-odcr` sets `CapacityReservationTarget` **without** `MarketType=capacity-block`
-  and **keeps** the placement group (On-Demand billing against the reservation).
-  `none`/`capacity-block` stay equivalent to today (backward compatible). Replaces the
-  current "do not put an ODCR ID here" caveat. Verification can be done **without GPU
-  capacity**: (1) static — create the GPU CNGs with `Min/MaxCount=0` and assert the
-  generated launch template's `CapacityReservationSpecification`/`InstanceMarketOptions`/
-  `Placement` per type; (2) dynamic — the branch logic is instance-family-independent, so
-  exercise actual targeted-ODCR consumption (`InstanceLifecycle` empty = On-Demand, reserved
-  count decrements) on a cheap type (c6i/g5).
+- [x] ✅ **Targeted ODCR support for GPU node groups.** Done: `CapacityReservationType`
+  (`capacity-block` | `targeted-odcr`) on `add-cng-p5`/`add-cng-p6-b200`/`add-cng-p6-b300`
+  plus a `PlacementGroupName` parameter for reusing an existing cluster placement group
+  (`PseriesPlacementGroupName` on deploy-all). `targeted-odcr` sets
+  `CapacityReservationTarget` **without** `MarketType=capacity-block` and **keeps** the
+  placement group (On-Demand billing against the reservation);
+  `capacity-block` (the default) is unchanged and backward compatible. Verified without
+  GPU capacity by the static method below: a launch-template-only harness deployed in all
+  three modes, reading back the generated `LaunchTemplateData` —
+  On-Demand → `MarketType=null, crid=null, pg=<new>`;
+  `capacity-block` → `MarketType=capacity-block, crid=<id>, pg=null`;
+  `targeted-odcr` → `MarketType=null, crid=<id>, pg=<existing group>`.
+  Actual reserved-capacity consumption on real p5 hardware is still to be confirmed.
 - [ ] 🟡 **Scope down the instance role's `AmazonS3ReadOnlyAccess`.** The PCS instance
   role in `cluster.yaml` attaches `AmazonS3ReadOnlyAccess` **unconditionally** (every node
   can read every S3 bucket in the account). The upstream

--- a/architectures/aws-pcs/docs/ROADMAP.md
+++ b/architectures/aws-pcs/docs/ROADMAP.md
@@ -26,7 +26,13 @@ Priority: 🔴 high · 🟡 medium · 🟢 low
   On-Demand → `MarketType=null, crid=null, pg=<new>`;
   `capacity-block` → `MarketType=capacity-block, crid=<id>, pg=null`;
   `targeted-odcr` → `MarketType=null, crid=<id>, pg=<existing group>`.
-  Actual reserved-capacity consumption on real p5 hardware is still to be confirmed.
+  **Confirmed end-to-end on real hardware** (2026-08-01): a PCS GPU node group
+  created with `CapacityReservationType=targeted-odcr` and an existing
+  placement group launched 2x p5.48xlarge that EC2 attributed to the targeted
+  reservation (`CapacityReservationId` set on both instances,
+  `Placement.GroupName` = the passed-in group) and the reservation's
+  `AvailableInstanceCount` went 2 -> 0, i.e. the capacity was actually consumed.
+  A Slurm job on the resulting `gpu` partition ran on both nodes.
 - [ ] 🟡 **Scope down the instance role's `AmazonS3ReadOnlyAccess`.** The PCS instance
   role in `cluster.yaml` attaches `AmazonS3ReadOnlyAccess` **unconditionally** (every node
   can read every S3 bucket in the account). The upstream

--- a/architectures/aws-pcs/docs/ROADMAP.md
+++ b/architectures/aws-pcs/docs/ROADMAP.md
@@ -33,6 +33,15 @@ Priority: 🔴 high · 🟡 medium · 🟢 low
   `Placement.GroupName` = the passed-in group) and the reservation's
   `AvailableInstanceCount` went 2 -> 0, i.e. the capacity was actually consumed.
   A Slurm job on the resulting `gpu` partition ran on both nodes.
+- [x] ✅ **P4d / P4de support.** `add-cng-p4d.yaml` (4 network cards, all EFA, card 0 on
+  DeviceIndex 0, cards 1-3 on DeviceIndex 1, per `describe-instance-types`
+  `NetworkInfo.NetworkCards` / `EfaInfo.MaximumEfaInterfaces = 4`; identical for
+  p4d.24xlarge and p4de.24xlarge) plus a `P4DCNGStack` branch in deploy-all
+  (`PseriesInstanceType` accepts `p4d.24xlarge` / `p4de.24xlarge`). Verified with the
+  static method (2026-09-08, us-west-2, no GPU capacity): CNGs created with
+  `Min/MaxCount=0` for both types reached ACTIVE and the generated launch template
+  carried the 4-NIC EFA layout, `MarketType=null`, a new placement group. A live boot
+  is pending the re:Invent dry-run ODCR (2x p4d.24xlarge, CTI P508054549).
 - [ ] 🟡 **Scope down the instance role's `AmazonS3ReadOnlyAccess`.** The PCS instance
   role in `cluster.yaml` attaches `AmazonS3ReadOnlyAccess` **unconditionally** (every node
   can read every S3 bucket in the account). The upstream
@@ -61,8 +70,8 @@ Priority: 🔴 high · 🟡 medium · 🟢 low
   with a different NIC/EFA layout (e.g. p6e-gb200 = 17 network cards) and likely need an
   arm64 PCS-Ready DLAMI and arm64 Enroot/Pyxis builds — validate the AMI, EFA, and a
   sample run.
-- [ ] 🟢 **Consolidate the per-family GPU add-cng templates (p5 / p6-b200 / p6-b300).**
-  The three `add-cng-p6*`/`add-cng-p5` templates are ~85% identical; the real difference
+- [ ] 🟢 **Consolidate the per-family GPU add-cng templates (p4d / p5 / p6-b200 / p6-b300).**
+  The four `add-cng-p4d`/`add-cng-p5`/`add-cng-p6*` templates are ~85% identical; the real difference
   is the `NetworkInterfaces` EFA layout (card count, whether card 0 is EFA or ENA-only, and
   the EFA DeviceIndex). They are kept separate today so each NIC list stays flat and
   hand-checkable against the EC2 docs. Investigate generating the interface list from a

--- a/architectures/aws-pcs/tests/gpu-healthcheck-test.md
+++ b/architectures/aws-pcs/tests/gpu-healthcheck-test.md
@@ -74,9 +74,43 @@ per-deploy gate.
   a node with other GPU work.
 
 > **⚠️ Validate multi-node NCCL via [compute-test.md Test 6](./compute-test.md#test-6-nccl-multi-node-efa),
-> not intensive check 5.** The suite's `checks/5-nccl-allreduce.sh` defaults to an ECR image
-> URI that enroot rejects (needs the `#` registry separator,
-> `docker://public.ecr.aws#hpc-cloud/nccl-tests:<tag>`), and invokes `all_reduce_perf` by
-> bare name when that image keeps the binaries under `/opt/nccl-tests/build/` (not on
-> `PATH`). The canonical `nccl-tests-container.sbatch` in Test 6 handles both correctly and
-> ran to 377 GB/s on this cluster.
+> not intensive check 5** — until the suite fix lands. The suite's
+> `checks/5-nccl-allreduce.sh` defaults to an ECR image URI that enroot rejects (needs the
+> `#` registry separator, `docker://public.ecr.aws#hpc-cloud/nccl-tests:<tag>`), and invokes
+> `all_reduce_perf` by bare name when that image keeps the binaries under
+> `/opt/nccl-tests/build/` (not on `PATH`). The canonical `nccl-tests-container.sbatch` in
+> Test 6 handles both correctly and ran to 377 GB/s on this cluster.
+>
+> Measured consequence on **p5.48xlarge ×2** (Slurm 25.11, 2026-08-01): stock
+> `--check 5` exits 1 after **2.7 s** and reports **severity RESET** on nodes that sustain
+> **445.33 GB/s** all-reduce with `#wrong=0` immediately afterwards — i.e. a false RESET on
+> healthy hardware. Both causes are fixed by
+> `checks/5-nccl-allreduce.sh`'s `NCCL_CONTAINER` (`#` separator) and the new
+> `NCCL_TESTS_BIN` override; once that is merged, check 5 is usable here and this warning
+> can be reduced to a version note.
+
+### Verified on p5.48xlarge (us-east-1, 2026-08-01, Slurm 25.11)
+
+Lightweight suite on **p5.48xlarge** via `srun -p gpu`, per-check wall clock
+(driver 595.71.05, DCGM 4.6.0, libfabric 2.4.0amzn1.0, 32 EFA devices):
+
+| Check | Result | Wall clock |
+|---|---|---|
+| 0 nvidia-smi | PASS — 8× H100 80GB HBM3, no Xid/SXid | **3.12 s** |
+| 1 DCGM L2 | PASS — all Level-2 diagnostics | **254.62 s** |
+| 2 EFA enumeration | PASS — 32 EFA PCI / 32 RDMA / 32 uverbs | **2.24 s** |
+| 3 Topology | PASS — 8 GPUs, NVLink validated | **3.27 s** |
+| **lightweight total** | 4/4 PASS | **≈263 s** (**8.6 s** without DCGM L2) |
+| 6 EFA loopback | PASS ×6 consecutive runs, 32 domains each | **138.70–139.10 s** |
+| prolog (checks 0+2) | ×3 runs | **3.46 / 3.37 / 3.37 s** |
+
+Two notes for PCS specifically:
+
+- **The PCS-Ready DLAMI ships the EFA userspace** at `/opt/amazon/efa/bin`
+  (`fi_info`, `fi_pingpong`, libfabric 2.4.0amzn1.0) but does **not** put it on `PATH`,
+  so checks 2 and 6 log `fi_info not found` / `fi_pingpong not found on PATH` as a WARN.
+  Check 6 then adds the directory itself and runs normally — the WARN is cosmetic, not a
+  skipped test. (Contrast with EKS GPU AMIs, where `/opt/amazon/efa` is genuinely empty.)
+- Under `sbatch`, `PATH` may be **unset**, so a script that does
+  `export PATH=/some/dir:$PATH` ends up with only `/some/dir` and loses coreutils. Seed the
+  standard directories explicitly in Slurm job scripts.


### PR DESCRIPTION
## Scope

This PR changes `architectures/aws-pcs/` in two parts: targeted On-Demand Capacity Reservation (ODCR) support for the GPU `add-cng-*` templates, and a new node group template for p4d.24xlarge and p4de.24xlarge. The first part is the three commits from `feat/pcs-targeted-odcr` rebased on `main`; the second part builds on it.

## Targeted ODCR on GPU node groups

The GPU templates gain a `CapacityReservationType` parameter with two values. `capacity-block` (the default) keeps today's behaviour: `CapacityReservationId` names a Capacity Block for ML, the launch template sets `MarketType=capacity-block`, and no placement group is attached. `targeted-odcr` sets `CapacityReservationTarget` to the given reservation, leaves `MarketType` unset so billing stays On-Demand against the reservation, and attaches a cluster placement group. A new `PlacementGroupName` parameter reuses an existing placement group, which EC2 requires when the reservation itself was created inside one. deploy-all exposes both as `CapacityReservationType` and `PseriesPlacementGroupName`.

## P4d / P4de node group template

`add-cng-p4d.yaml` carries a 4-network-card EFA layout: card 0 on DeviceIndex 0, cards 1 to 3 on DeviceIndex 1, all `InterfaceType: efa`. `InstanceType` is locked to `p4d.24xlarge` and `p4de.24xlarge`. `describe-instance-types` reports the same `NetworkInfo.NetworkCards` (4 cards, 100 Gigabit each) and `EfaInfo.MaximumEfaInterfaces = 4` for both types, so one template covers both. deploy-all adds `p4d.24xlarge` and `p4de.24xlarge` to `PseriesInstanceType`, a `PseriesIsP4D` condition, and a `P4DCNGStack` nested stack; `PseriesIsP5` excludes the two types. README, `docs/PARAMETERS.md` and `docs/ROADMAP.md` are updated and `tests/lint-docs.sh` passes.

## Verification of the targeted ODCR path (2026-08-01)

A launch-template-only harness was deployed in the three modes and the generated `LaunchTemplateData` read back: On-Demand gives `MarketType=null`, no reservation id, a new placement group; `capacity-block` gives `MarketType=capacity-block`, the reservation id, no placement group; `targeted-odcr` gives `MarketType=null`, the reservation id, the existing placement group. On hardware, a GPU node group created with `CapacityReservationType=targeted-odcr` and an existing placement group launched 2 p5.48xlarge instances that EC2 attributed to the targeted reservation (`AvailableInstanceCount` went from 2 to 0) and a Slurm job ran on both nodes.

## Verification of add-cng-p4d.yaml (2026-09-08, us-west-2, cluster pcs_jdb4dviivh)

No p4d capacity was available, so the check is static. `add-cng-p4d.yaml` was deployed twice with `MinCount=MaxCount=0`: once as `p4d.24xlarge` with `CapacityReservationType=targeted-odcr`, once as `p4de.24xlarge` with `capacity-block`, both with an empty reservation id. Both stacks reached CREATE_COMPLETE, both PCS node groups reached ACTIVE with `purchaseOption=ONDEMAND`, and the generated launch template carried `(card, device, type) = (0,0,efa) (1,1,efa) (2,1,efa) (3,1,efa)`, `InstanceMarketOptions=null`, `CapacityReservationSpecification=null` and a new placement group. Passing a reservation from another AZ was rejected by PCS with "The availability zone of the compute node group subnet must match the availability zone of the capacity reservation". Both test stacks were deleted afterwards. `aws cloudformation validate-template` passes for `add-cng-p4d.yaml` and `pcs-ml-cluster-deploy-all.yaml`. `docs/ROADMAP.md` records the live p4d boot as pending capacity.

## Compatibility and publishing

`CapacityReservationType` defaults to `capacity-block` and existing `PseriesInstanceType` values select the same templates as before. The public template bucket is synced by CI after merge, and the README quick-create link for `add-cng-p4d.yaml` resolves once that sync has run.
